### PR TITLE
Feature/add verbosity level

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ After the installation with pip, you can use somesy as a CLI tool. `somesy sync`
 | somesy sync | --cff-file, -c          | cff file path       | set CITATION.cff file to sync          |
 | somesy sync | --no-sync-pyproject, -P | -                   | Do not sync pyproject file             |
 | somesy sync | --pyproject-file, -p    | pyproject file path | set pyproject file to sync             |
+| somesy sync | --show-info, -s         | -                   | show basic information messages        |
 | somesy sync | --verbose, -v           | -                   | show verbose messages                  |
 | somesy sync | --debug, -d             | -                   | show debug messages, overrides verbose |
 
-`somesy` is designed to be used as a pre-commit tool so it does not give any output unless there is an error or either of verbose or debug flag is set. Also, `somesy` will give an error if there is no output to sync.
+`somesy` is designed to be used as a pre-commit tool so it does not give any output unless there is an error or one of the related flags is set. Also, `somesy` will give an error if there is no output to sync.
 
 ### Use as a Pre-commit hook
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,3 +136,6 @@ exclude_dirs = ["tests", "scripts"]
 
 [tool.licensecheck]
 using = "poetry"
+
+[tool.mypy]
+disable_error_code = ["attr-defined"]

--- a/src/somesy/commands/sync.py
+++ b/src/somesy/commands/sync.py
@@ -44,12 +44,12 @@ def _sync_python(
         metadata (ProjectMetadata): project metadata to sync pyproject.toml file.
         pyproject_file (Path, optional): pyproject file to read project metadata from.
     """
-    logger.verbose("Loading pyproject.toml file.")  # type: ignore
+    logger.verbose("Loading pyproject.toml file.")
     pyproject = Pyproject(pyproject_file)
-    logger.verbose("Syncing pyproject.toml file.")  # type: ignore
+    logger.verbose("Syncing pyproject.toml file.")
     pyproject.sync(metadata)
     pyproject.save()
-    logger.verbose("Saved synced pyproject.toml file.\n")  # type: ignore
+    logger.verbose("Saved synced pyproject.toml file.\n")
 
 
 def _sync_cff(
@@ -64,9 +64,9 @@ def _sync_cff(
         cff_file (Path, optional): CFF file path if wanted to be synced. Defaults to None.
         create_cff (bool, optional): Create CFF file if does not exist. Defaults to True.
     """
-    logger.verbose("Loading CITATION.cff file.")  # type: ignore
+    logger.verbose("Loading CITATION.cff file.")
     cff = CFF(cff_file, create_cff)
-    logger.verbose("Syncing CITATION.cff file.")  # type: ignore
+    logger.verbose("Syncing CITATION.cff file.")
     cff.sync(metadata)
     cff.save()
-    logger.verbose("Saved synced CITATION.cff file.\n")  # type: ignore
+    logger.verbose("Saved synced CITATION.cff file.\n")

--- a/src/somesy/commands/sync.py
+++ b/src/somesy/commands/sync.py
@@ -36,7 +36,7 @@ def sync(
 
 def _sync_python(
     metadata: ProjectMetadata,
-    pyproject_file: Optional[Path] = None,
+    pyproject_file: Path,
 ):
     """Sync pyproject.toml file using project metadata.
 
@@ -54,7 +54,7 @@ def _sync_python(
 
 def _sync_cff(
     metadata: ProjectMetadata,
-    cff_file: Optional[Path] = None,
+    cff_file: Path,
     create_cff: bool = True,
 ):
     """Sync CITATION.cff file using project metadata.

--- a/src/somesy/core/discover.py
+++ b/src/somesy/core/discover.py
@@ -25,13 +25,13 @@ def discover_input(input_file: Optional[Path] = None) -> Path:
             logger.info(f"Using given {input_file} as somesy input file.")
             return input_file
         else:
-            logger.verbose(  # type: ignore
+            logger.verbose(
                 f"Given input file {input_file} does not exist. Trying to find somesy input file from defaults."
             )
     for filename in INPUT_FILES_ORDERED:
         input_file = Path(filename)
         if input_file.is_file():
-            logger.verbose(  # type: ignore
+            logger.verbose(
                 f"Using {input_file} from default somesy config list as somesy input file."
             )
             return input_file

--- a/src/somesy/core/discover.py
+++ b/src/somesy/core/discover.py
@@ -8,7 +8,7 @@ from .config import INPUT_FILES_ORDERED
 logger = logging.getLogger("somesy")
 
 
-def discover_input(input_file: Optional[Path] = None) -> Optional[Path]:
+def discover_input(input_file: Optional[Path] = None) -> Path:
     """Check given input file path. If not given, find somesy configuration file path from default list.
 
     Args:

--- a/src/somesy/core/discover.py
+++ b/src/somesy/core/discover.py
@@ -22,7 +22,7 @@ def discover_input(input_file: Optional[Path] = None) -> Path:
     """
     if input_file:
         if input_file.is_file():
-            logger.verbose(f"Using given {input_file} as somesy input file.")  # type: ignore
+            logger.info(f"Using given {input_file} as somesy input file.")
             return input_file
         else:
             logger.verbose(  # type: ignore

--- a/src/somesy/core/utils.py
+++ b/src/somesy/core/utils.py
@@ -8,15 +8,13 @@ from somesy.core.config import VERBOSE
 logger = logging.getLogger("somesy")
 
 
-def set_logger(
-    debug: bool = False, verbose: bool = False, no_quiet: bool = False
-) -> None:
+def set_logger(debug: bool = False, verbose: bool = False, info: bool = False) -> None:
     """Set logger to rich handler and add custom logging level.
 
     Args:
-        debug (bool): Debug mode, overrides verbose and no_quiet modes.
+        debug (bool): Debug mode, overrides verbose and info modes.
         verbose (bool): Verbose mode.
-        no_quiet (bool): NO quiet mode, prints basic output.
+        info (bool): NO quiet mode, prints basic output.
     """
     logging.addLevelName(level=VERBOSE, levelName="VERBOSE")
     logger.propagate = False
@@ -25,7 +23,7 @@ def set_logger(
         logger.setLevel(logging.DEBUG)
     elif verbose:
         logger.setLevel(VERBOSE)
-    elif no_quiet:
+    elif info:
         logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)

--- a/src/somesy/core/utils.py
+++ b/src/somesy/core/utils.py
@@ -9,14 +9,14 @@ logger = logging.getLogger("somesy")
 
 
 def set_logger(
-    debug: bool = False, verbose: bool = False, no_quite: bool = False
+    debug: bool = False, verbose: bool = False, no_quiet: bool = False
 ) -> None:
     """Set logger to rich handler and add custom logging level.
 
     Args:
-        debug (bool): Debug mode, overrides verbose and no_quite modes.
+        debug (bool): Debug mode, overrides verbose and no_quiet modes.
         verbose (bool): Verbose mode.
-        no_quite (bool): NO Quite mode, prints basic output.
+        no_quiet (bool): NO quiet mode, prints basic output.
     """
     logging.addLevelName(level=VERBOSE, levelName="VERBOSE")
     logger.propagate = False
@@ -25,7 +25,7 @@ def set_logger(
         logger.setLevel(logging.DEBUG)
     elif verbose:
         logger.setLevel(VERBOSE)
-    elif no_quite:
+    elif no_quiet:
         logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)

--- a/src/somesy/core/utils.py
+++ b/src/somesy/core/utils.py
@@ -8,16 +8,19 @@ from somesy.core.config import VERBOSE
 logger = logging.getLogger("somesy")
 
 
-def set_logger(debug: bool = False, verbose: bool = False, no_quite: bool = False) -> None:
+def set_logger(
+    debug: bool = False, verbose: bool = False, no_quite: bool = False
+) -> None:
     """Set logger to rich handler and add custom logging level.
 
     Args:
-        debug (bool): Debug mode, overrides verbose mode.
+        debug (bool): Debug mode, overrides verbose and no_quite modes.
         verbose (bool): Verbose mode.
+        no_quite (bool): NO Quite mode, prints basic output.
     """
     logging.addLevelName(level=VERBOSE, levelName="VERBOSE")
     logger.propagate = False
-    
+
     if debug:
         logger.setLevel(logging.DEBUG)
     elif verbose:

--- a/src/somesy/core/utils.py
+++ b/src/somesy/core/utils.py
@@ -8,7 +8,7 @@ from somesy.core.config import VERBOSE
 logger = logging.getLogger("somesy")
 
 
-def set_logger(debug: bool = False, verbose: bool = False) -> None:
+def set_logger(debug: bool = False, verbose: bool = False, no_quite: bool = False) -> None:
     """Set logger to rich handler and add custom logging level.
 
     Args:
@@ -17,13 +17,15 @@ def set_logger(debug: bool = False, verbose: bool = False) -> None:
     """
     logging.addLevelName(level=VERBOSE, levelName="VERBOSE")
     logger.propagate = False
-
+    
     if debug:
         logger.setLevel(logging.DEBUG)
     elif verbose:
         logger.setLevel(VERBOSE)
-    else:
+    elif no_quite:
         logger.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)
 
     def verbose_print(self, message, *args, **kwargs):
         """Verbose logging level print function."""

--- a/src/somesy/main.py
+++ b/src/somesy/main.py
@@ -79,10 +79,10 @@ def sync(
         resolve_path=True,
         help="Existing pyproject.toml file path",
     ),
-    no_quiet: bool = typer.Option(
+    show_info: bool = typer.Option(
         False,
-        "--no-quiet",
-        "-Q",
+        "--show-info",
+        "-s",
         help="Get basic output (somesy is quiet by default)",
     ),
     verbose: bool = typer.Option(
@@ -99,7 +99,7 @@ def sync(
     ),
 ):
     """Sync project metadata input with metadata files."""
-    set_logger(debug=debug, verbose=verbose, no_quiet=no_quiet)
+    set_logger(debug=debug, verbose=verbose, info=show_info)
     # at least one of the sync options must be enabled
     if no_sync_cff and no_sync_pyproject:
         logger.warning("There should be at least one file to sync.")

--- a/src/somesy/main.py
+++ b/src/somesy/main.py
@@ -106,7 +106,7 @@ def sync(
         typer.Exit(code=0)
 
     try:
-        logger.info("[bold green]Syncing project metadata...[/bold green]\n") 
+        logger.info("[bold green]Syncing project metadata...[/bold green]\n")
         logger.debug(
             f"CLI arguments:\n{input_file=}, {no_sync_cff=}, {cff_file=}, {no_sync_pyproject=}, {pyproject_file=}, {verbose=}, {debug=}"
         )
@@ -115,16 +115,14 @@ def sync(
         input_file = discover_input(input_file)
 
         # info output
-        logger.info("Files to sync:")  
+        logger.info("Files to sync:")
         if not no_sync_pyproject:
-            logger.info( 
+            logger.info(
                 f"  - [italic]Pyproject.toml[/italic] [grey]({pyproject_file})[/grey]"
             )
 
         if not no_sync_cff:
-            logger.info( 
-                f"  - [italic]CITATION.cff[/italic] [grey]({cff_file})[/grey]"
-            )
+            logger.info(f"  - [italic]CITATION.cff[/italic] [grey]({cff_file})[/grey]")
 
         # sync files
         sync_command(
@@ -133,7 +131,7 @@ def sync(
             cff_file=cff_file if not no_sync_cff else None,
         )
 
-        logger.info("[bold green]Syncing completed.[/bold green]") 
+        logger.info("[bold green]Syncing completed.[/bold green]")
     except Exception as e:
         logger.error(f"[bold red]Error: {e}[/bold red]")
         logger.debug(f"[red]{traceback.format_exc()}[/red]")

--- a/src/somesy/main.py
+++ b/src/somesy/main.py
@@ -79,11 +79,11 @@ def sync(
         resolve_path=True,
         help="Existing pyproject.toml file path",
     ),
-    no_quite: bool = typer.Option(
+    no_quiet: bool = typer.Option(
         False,
-        "--no-quite",
+        "--no-quiet",
         "-Q",
-        help="Get basic output (somesy is quite by default)",
+        help="Get basic output (somesy is quiet by default)",
     ),
     verbose: bool = typer.Option(
         False,
@@ -99,7 +99,7 @@ def sync(
     ),
 ):
     """Sync project metadata input with metadata files."""
-    set_logger(debug=debug, verbose=verbose, no_quite=no_quite)
+    set_logger(debug=debug, verbose=verbose, no_quiet=no_quiet)
     # at least one of the sync options must be enabled
     if no_sync_cff and no_sync_pyproject:
         logger.warning("There should be at least one file to sync.")

--- a/src/somesy/main.py
+++ b/src/somesy/main.py
@@ -79,6 +79,12 @@ def sync(
         resolve_path=True,
         help="Existing pyproject.toml file path",
     ),
+    no_quite: bool = typer.Option(
+        False,
+        "--no-quite",
+        "-Q",
+        help="Get basic output (somesy is quite by default)",
+    ),
     verbose: bool = typer.Option(
         False,
         "--verbose",
@@ -93,14 +99,14 @@ def sync(
     ),
 ):
     """Sync project metadata input with metadata files."""
-    set_logger(debug=debug, verbose=verbose)
+    set_logger(debug=debug, verbose=verbose, no_quite=no_quite)
     # at least one of the sync options must be enabled
     if no_sync_cff and no_sync_pyproject:
         logger.warning("There should be at least one file to sync.")
         typer.Exit(code=0)
 
     try:
-        logger.verbose("[bold green]Syncing project metadata...[/bold green]\n")  # type: ignore
+        logger.info("[bold green]Syncing project metadata...[/bold green]\n") 
         logger.debug(
             f"CLI arguments:\n{input_file=}, {no_sync_cff=}, {cff_file=}, {no_sync_pyproject=}, {pyproject_file=}, {verbose=}, {debug=}"
         )
@@ -108,18 +114,17 @@ def sync(
         # check if input file exists, if not, try to find it from default list
         input_file = discover_input(input_file)
 
-        # verbose output
-        logger.verbose("Files to sync:")  # type: ignore
+        # info output
+        logger.info("Files to sync:")  
         if not no_sync_pyproject:
-            logger.verbose(  # type: ignore
+            logger.info( 
                 f"  - [italic]Pyproject.toml[/italic] [grey]({pyproject_file})[/grey]"
             )
 
         if not no_sync_cff:
-            logger.verbose(  # type: ignore
+            logger.info( 
                 f"  - [italic]CITATION.cff[/italic] [grey]({cff_file})[/grey]"
             )
-        logger.verbose("\n")  # type: ignore
 
         # sync files
         sync_command(
@@ -128,7 +133,7 @@ def sync(
             cff_file=cff_file if not no_sync_cff else None,
         )
 
-        logger.verbose("[bold green]Syncing completed.[/bold green]")  # type: ignore
+        logger.info("[bold green]Syncing completed.[/bold green]") 
     except Exception as e:
         logger.error(f"[bold red]Error: {e}[/bold red]")
         logger.debug(f"[red]{traceback.format_exc()}[/red]")

--- a/src/somesy/pyproject/core.py
+++ b/src/somesy/pyproject/core.py
@@ -35,12 +35,12 @@ class Pyproject(wrapt.ObjectProxy):
 
         # setuptools has project object
         if "project" in data:
-            logger.verbose("Found setuptools config in pyproject.toml file")  # type: ignore
+            logger.verbose("Found setuptools config in pyproject.toml file")
             self.__wrapped__: Union[SetupTools, Poetry] = SetupTools(path)
             super().__init__(self.__wrapped__)
         # poetry has tool.poetry object
         elif "tool" in data and "poetry" in data["tool"]:
-            logger.verbose("Found poetry config in pyproject.toml file")  # type: ignore
+            logger.verbose("Found poetry config in pyproject.toml file")
             self.__wrapped__ = Poetry(path)
             super().__init__(self.__wrapped__)
         # value error if other project object is found

--- a/tests/core/test_core_utils.py
+++ b/tests/core/test_core_utils.py
@@ -20,7 +20,7 @@ def test_set_logger_verbose():
 
 def test_set_logger_info():
     # test debug mode
-    set_logger(no_quiet=True)
+    set_logger(info=True)
     assert logger.getEffectiveLevel() == logging.INFO
 
 

--- a/tests/core/test_core_utils.py
+++ b/tests/core/test_core_utils.py
@@ -20,7 +20,7 @@ def test_set_logger_verbose():
 
 def test_set_logger_info():
     # test debug mode
-    set_logger(no_quite=True)
+    set_logger(no_quiet=True)
     assert logger.getEffectiveLevel() == logging.INFO
 
 

--- a/tests/core/test_core_utils.py
+++ b/tests/core/test_core_utils.py
@@ -20,5 +20,11 @@ def test_set_logger_verbose():
 
 def test_set_logger_info():
     # test debug mode
-    set_logger()
+    set_logger(no_quite=True)
     assert logger.getEffectiveLevel() == logging.INFO
+
+
+def test_set_logger_warning():
+    # test debug mode
+    set_logger()
+    assert logger.getEffectiveLevel() == logging.WARNING

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,7 +29,7 @@ def test_app_sync(tmp_path, create_poetry_file, mocker):
         [
             "sync",
             "-i",
-            input_file,
+            str(input_file),
             "--no-sync-pyproject",
             "--no-sync-cff",
         ],
@@ -46,7 +46,7 @@ def test_app_sync(tmp_path, create_poetry_file, mocker):
         [
             "sync",
             "-i",
-            input_file,
+            str(input_file),
             "-c",
             cff_file,
             "-p",
@@ -67,7 +67,7 @@ def test_app_sync(tmp_path, create_poetry_file, mocker):
         [
             "sync",
             "-i",
-            input_file_reject,
+            str(input_file_reject),
             "-d",
         ],
     )


### PR DESCRIPTION
Since `somesy` is designed to be a pre-commit tool, it is quiet by default. I added a new CLI option to give basic information, less verbose than the verbose option. 

resolves #3 

- made default log level WARNING
- added a new cli options as no-quite that gives a basic info