### PR TITLE
contribution type accept list

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Somesy input has the information on what is the most important for metadata and 
 - tel: The person's phone number. - String
 - website: The person's website. - String in URL format
 - contribution: Summary of how the person contributed to the project. - String
-- contribution_type: Contribution type of contributor using emoji from [all contributors](https://allcontributors.org/docs/en/emoji-key). - String in emoji name
+- contribution_type: Contribution type of contributor using emoji from [all contributors](https://allcontributors.org/docs/en/emoji-key). - String in emoji name or list of strings
 - contribution_begin: Beginning date of the contribution. - Date in YYYY-MM-DD format
 - contribution_end: Ending date of the contribution. - Date in YYYY-MM-DD format
 

--- a/src/somesy/core/models.py
+++ b/src/somesy/core/models.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from datetime import date
 from enum import Enum
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, Extra, Field
 from typing_extensions import Annotated
@@ -859,9 +859,9 @@ class Person(BaseModel):
             ),
         ]
     ]
-    contribution_type: Optional[ContributionTypeEnum] = Field(
-        None, description="Contribution type of contributor."
-    )
+    contribution_type: Optional[
+        Union[ContributionTypeEnum, List[ContributionTypeEnum]]
+    ] = Field(None, description="Contribution type of contributor.")
     contribution_begin: Optional[date] = Field(
         None, description="Beginning date of the contribution."
     )


### PR DESCRIPTION
The person class of project metadata only accepts a string for contribution type. This PR updates the pydantic class of Person to accept both a string and a list of strings. Since this field is not used for either CFF or pyproject outputs, only the input class is updated.