### PR TITLE
feature: select codemetapy sources based on somesy configuration

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -11,11 +11,11 @@
     "audience": [
         {
             "@type": "Audience",
-            "audienceType": "Developers"
+            "audienceType": "Science/Research"
         },
         {
             "@type": "Audience",
-            "audienceType": "Science/Research"
+            "audienceType": "Developers"
         }
     ],
     "author": [

--- a/src/somesy/cli/sync.py
+++ b/src/somesy/cli/sync.py
@@ -138,38 +138,31 @@ def sync(
         if cli_log_level is None:
             set_log_level(config_log_level)
 
-        # --------
-
         logger.debug(f"Combined config (Defaults + File + CLI):\n{pretty_repr(conf)}")
-
-        # info output
-        logger.info("[bold green]Syncing project metadata...[/bold green]")
-        logger.info("Files to sync:")
-        if not conf.no_sync_pyproject:
-            logger.info(
-                f"  - [italic]pyproject.toml[/italic]:\t[grey]{conf.pyproject_file}[/grey]"
-            )
-        if not conf.no_sync_cff:
-            logger.info(
-                f"  - [italic]CITATION.cff[/italic]:\t[grey]{conf.cff_file}[/grey]"
-            )
-        if not conf.no_sync_codemeta:
-            logger.info(
-                f"  - [italic]codemeta.json[/italic]:\t[grey]{conf.codemeta_file}[/grey]\n"
-            )
-
-        # ----------
-        # sync files (passing paths only if the target is not disabled)
-        sync_command(
-            input_file=conf.input_file,
-            pyproject_file=conf.pyproject_file if not conf.no_sync_pyproject else None,
-            cff_file=conf.cff_file if not conf.no_sync_cff else None,
-            codemeta_file=conf.codemeta_file if not conf.no_sync_codemeta else None,
-        )
-
-        logger.info("[bold green]Syncing completed.[/bold green]")
+        # --------
+        run_sync(conf)
 
     except Exception as e:
         logger.error(f"[bold red]Error: {e}[/bold red]")
         logger.debug(f"[red]{traceback.format_exc()}[/red]")
         raise typer.Exit(code=1)
+
+
+def run_sync(conf: SomesyConfig):
+    """Write log messages and run synchronization based on passed config."""
+    logger.info("[bold green]Synchronizing project metadata...[/bold green]")
+    logger.info("Files to sync:")
+    if not conf.no_sync_pyproject:
+        logger.info(
+            f"  - [italic]pyproject.toml[/italic]:\t[grey]{conf.pyproject_file}[/grey]"
+        )
+    if not conf.no_sync_cff:
+        logger.info(f"  - [italic]CITATION.cff[/italic]:\t[grey]{conf.cff_file}[/grey]")
+    if not conf.no_sync_codemeta:
+        logger.info(
+            f"  - [italic]codemeta.json[/italic]:\t[grey]{conf.codemeta_file}[/grey]\n"
+        )
+    # ----
+    sync_command(conf)
+    # ----
+    logger.info("[bold green]Metadata synchronization completed.[/bold green]")

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -1,46 +1,51 @@
 """Integration with codemetapy (to re-generate codemeta as part of somesy sync)."""
+import contextlib
 import logging
 from pathlib import Path
-from typing import Optional
 
+from ..core.models import SomesyConfig
 from .exec import gen_codemeta
 from .utils import cff_codemeta_tempfile, update_codemeta_file
 
 log = logging.getLogger("somesy")
 
 
-def update_codemeta(cm_file: Path, cff_file: Optional[Path]) -> bool:
+def collect_cm_sources(conf: SomesyConfig):
+    """Assemble list of inputs for codemetapy based on somesy config.
+
+    Returns files that are supported by both somesy and codemetapy and are enabled for somesy.
+    """
+    cm_sources = []
+    if (
+        not conf.no_sync_pyproject
+        and conf.pyproject_file is not None
+        and conf.pyproject_file.is_file()
+    ):
+        cm_sources.append(conf.pyproject_file)
+    # NOTE: we don't add CFF directly, because it must be handled separately
+    # NOTE: add other suitable somesy targets / codemeta sources (except CFF and codemeta) here
+    return cm_sources
+
+
+def update_codemeta(conf: SomesyConfig) -> bool:
     """Generate or update codemeta file based on sources that somesy supports.
 
     Returns True if file has been written, False if it was up to date.
     """
-    log.verbose("Updating codemeta.json file.")
+    cm_sources = collect_cm_sources(conf)
 
-    # NOTE: other files that should be listed here are files
-    # * supported by somesy, and
-    # * enabled by somesy config (created/synced), and
-    # * supported by codemetapy
-    cm_sources = ["pyproject.toml"]
+    # if cff file is given, convert it to codemeta tempfile and pass as extra input
+    temp_cff_cm = contextlib.nullcontext(None)
+    if not conf.no_sync_cff and conf.cff_file is not None:
+        temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
+        cm_sources.append(Path(temp_cff_cm.name))
 
-    # if cff file is given, convert it to codemeta and pass as extra input
-    temp_cff_cm = None
-    if cff_file is not None:
-        temp_cff_cm = cff_codemeta_tempfile(cff_file)
-        cm_sources.append(temp_cff_cm.name)
+    # run codemetapy
+    with temp_cff_cm:
+        cm_harvest = gen_codemeta(cm_sources)
 
-    # harvest suitable files
-    cm_harvest = gen_codemeta(cm_sources)
-
-    if temp_cff_cm is not None:
-        # close + auto-remove temp file
-        temp_cff_cm.close()
-
-    if update_codemeta_file(cm_file, cm_harvest):
-        log.verbose(f"New codemeta graph written to {cm_file}.")
-        return True
-    else:
-        log.verbose(f"Codemeta graph unchanged, keeping old {cm_file}.")
-        return False
+    # check output and write file if needed
+    return update_codemeta_file(conf.codemeta_file, cm_harvest)
 
 
 __all__ = ["update_codemeta"]

--- a/src/somesy/codemeta/exec.py
+++ b/src/somesy/codemeta/exec.py
@@ -20,6 +20,7 @@ def cff_to_codemeta(cff_file: Path) -> Dict:
 
 def gen_codemeta(sources: List[str], *, with_entrypoints: bool = True) -> Dict:
     """Harvest codemeta LD dict via codemetapy."""
+    log.debug(f"Running codemetapy with sources {sources}")
     with redirect_stderr(StringIO()) as cm_log:
         g, res, args, _ = build(
             inputsources=list(map(str, sources)),

--- a/src/somesy/codemeta/utils.py
+++ b/src/somesy/codemeta/utils.py
@@ -101,7 +101,7 @@ def update_codemeta_file(cm_file: Path, cm_dict: Dict) -> bool:
 def cff_codemeta_tempfile(cff_file: Path):
     """Returns named temporary file with codemeta export of citation file."""
     cm_cff = cff_to_codemeta(cff_file)
-    temp_cff_cm = NamedTemporaryFile(suffix=".json")
+    temp_cff_cm = NamedTemporaryFile(prefix="cff_cm_", suffix=".json")
     temp_cff_cm.write(json.dumps(cm_cff).encode("utf-8"))
     temp_cff_cm.flush()  # needed, or it won't be readable yet
     return temp_cff_cm

--- a/tests/cli/test_command_sync.py
+++ b/tests/cli/test_command_sync.py
@@ -48,8 +48,9 @@ def test_app_sync(tmp_path, create_poetry_file, mocker):
             codemeta_file,
         ],
     )
+    print(result.output)
     assert result.exit_code == 0
-    assert "Syncing completed." in result.stdout
+    assert "Metadata synchronization completed." in result.stdout
     assert not cff_file.is_file()  # disabled in input_file!
     assert pyproject_file.is_file()
     assert codemeta_file.is_file()

--- a/tests/commands/test_sync.py
+++ b/tests/commands/test_sync.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from somesy.commands.sync import sync
+from somesy.core.models import SomesyConfig
 
 
 def test_sync(tmp_path, create_poetry_file):
@@ -12,7 +13,10 @@ def test_sync(tmp_path, create_poetry_file):
     create_poetry_file(pyproject_file)
 
     # TEST 1: sync only pyproject.toml
-    sync(input_file=input_file, pyproject_file=pyproject_file)
+    conf = SomesyConfig(
+        input_file=input_file, pyproject_file=pyproject_file, no_sync_cff=True
+    )
+    sync(conf)
     assert pyproject_file.is_file()
     assert cff_file.is_file() is False
 
@@ -20,7 +24,10 @@ def test_sync(tmp_path, create_poetry_file):
     pyproject_file.unlink()
 
     # TEST 2: sync only CITATION.cff
-    sync(input_file=input_file, cff_file=cff_file)
+    conf = SomesyConfig(
+        input_file=input_file, no_sync_pyproject=True, cff_file=cff_file
+    )
+    sync(conf)
     assert pyproject_file.is_file() is False
     assert cff_file.is_file()
 
@@ -31,6 +38,9 @@ def test_sync(tmp_path, create_poetry_file):
     create_poetry_file(pyproject_file)
 
     # TEST 3: sync both pyproject.toml and CITATION.cff
-    sync(input_file=input_file, pyproject_file=pyproject_file, cff_file=cff_file)
+    conf = SomesyConfig(
+        input_file=input_file, pyproject_file=pyproject_file, cff_file=cff_file
+    )
+    sync(conf)
     assert pyproject_file.is_file()
     assert cff_file.is_file()

--- a/tests/test_codemeta.py
+++ b/tests/test_codemeta.py
@@ -12,6 +12,7 @@ from somesy.codemeta.utils import (
     _graph_from_cm_file,
     _localize_codemetapy_context,
 )
+from somesy.core.models import SomesyConfig
 
 cm_dict = {
     "@context": list(_codemeta_context),
@@ -102,12 +103,13 @@ def test_update_codemeta(tmp_path):
     assert cff_path.is_file()
 
     # first time, no file -> codemeta.json is created
-    assert update_codemeta(file_path, cff_path)
+    conf = SomesyConfig(codemeta_file=file_path, cff_file=cff_path)
+    assert update_codemeta(conf)
 
     # second time, no changes -> codemeta.json is not overwritten
-    assert not update_codemeta(file_path, cff_path)
+    assert not update_codemeta(conf)
 
     cff.description = "Changed description"
     cff.save()
     # second time, changes -> codemeta.json is overwritten
-    assert update_codemeta(file_path, cff_path)
+    assert update_codemeta(conf)


### PR DESCRIPTION
NOTE: no idea why the `codemeta.json` file swapped the fields again, but re-running keeps it apparently consistent...

Please test it with your JS project to check whether it resolves your problem.

closes #22 