### PR TITLE
Fix/windows path error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Check that tests complete without errors
         run: |
           poetry install
-          poetry run poe test
+          poetry run poe test -s
 
   docs:
     # build + deploy documentation (only on push event for certain branches+tags)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ Thumbs.db
 .sonarqube
 .scannerwork
 .idea
+
+# windows temporary files
+Temp

--- a/codemeta.json
+++ b/codemeta.json
@@ -68,14 +68,14 @@
             "identifier": "'version':",
             "name": "'version':",
             "runtimePlatform": "Python 3",
-            "version": "'^0.7.0'}"
+            "version": "'^2.4.2'}"
         },
         {
             "@type": "SoftwareApplication",
             "identifier": "'version':",
             "name": "'version':",
             "runtimePlatform": "Python 3",
-            "version": "'^2.4.2'}"
+            "version": "'^0.7.0'}"
         },
         {
             "@type": "SoftwareApplication",
@@ -111,6 +111,13 @@
             "name": "packaging",
             "runtimePlatform": "Python 3",
             "version": "^23.1"
+        },
+        {
+            "@type": "SoftwareApplication",
+            "identifier": "platformdirs",
+            "name": "platformdirs",
+            "runtimePlatform": "Python 3",
+            "version": "^4.0.0"
         },
         {
             "@type": "SoftwareApplication",

--- a/poetry.lock
+++ b/poetry.lock
@@ -1468,13 +1468,13 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
+version = "4.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
+    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
 ]
 
 [package.extras]
@@ -2486,19 +2486,19 @@ test = ["coverage", "flake8 (>=3.7)", "mypy", "pretend", "pytest"]
 
 [[package]]
 name = "virtualenv"
-version = "20.24.5"
+version = "20.24.7"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.24.5-py3-none-any.whl", hash = "sha256:b80039f280f4919c77b30f1c23294ae357c4c8701042086e3fc005963e4e537b"},
-    {file = "virtualenv-20.24.5.tar.gz", hash = "sha256:e8361967f6da6fbdf1426483bfe9fca8287c242ac0bc30429905721cefbff752"},
+    {file = "virtualenv-20.24.7-py3-none-any.whl", hash = "sha256:a18b3fd0314ca59a2e9f4b556819ed07183b3e9a3702ecfe213f593d44f7b3fd"},
+    {file = "virtualenv-20.24.7.tar.gz", hash = "sha256:69050ffb42419c91f6c1284a7b24e0475d793447e35929b488bf6a0aade39353"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = ">=3.12.2,<4"
-platformdirs = ">=3.9.1,<4"
+platformdirs = ">=3.9.1,<5"
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
@@ -2667,4 +2667,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8b6a28e17adb56e6ee3101b938e5c41cdb3df4907a9321bf29d7eec09caac7d7"
+content-hash = "df761ead470c062f6ac722b4b27f2ee733ebc37835cbab3ccf67571daf1626ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ packaging = "^23.1"
 rdflib = "^6.3.2"
 codemetapy = "^2.5.1"
 jinja2 = "^3.1.2"
+platformdirs = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 poethepoet = "^0.18.1"

--- a/src/somesy/__init__.py
+++ b/src/somesy/__init__.py
@@ -1,6 +1,24 @@
 """somesy package."""
 import importlib_metadata
+from typing import Optional
 from typing_extensions import Final
+import platform
+from pathlib import Path
+from os import environ
 
 # Set version, it will use version from pyproject.toml if defined
 __version__: Final[str] = importlib_metadata.version(__package__ or __name__)
+
+# Set tmp dir for Windows
+__tmp_dir__: Optional[str] = None
+
+if platform.system() == "Windows":
+    # create temp folder
+    driver_letter = Path(__file__).drive
+    temp_folder = Path(f"{driver_letter}//Temp")
+    temp_folder.mkdir(parents=True, exist_ok=True)
+
+    # resolve temp folder to absolute path
+    resolved_temp_folder = str(temp_folder.resolve())
+    __tmp_dir__ = resolved_temp_folder
+    environ["TMPDIR"] = resolved_temp_folder

--- a/src/somesy/__init__.py
+++ b/src/somesy/__init__.py
@@ -1,31 +1,6 @@
 """somesy package."""
-import platform
-from os import environ
-from pathlib import Path
-from typing import Optional
-
 import importlib_metadata
 from typing_extensions import Final
 
 # Set version, it will use version from pyproject.toml if defined
 __version__: Final[str] = importlib_metadata.version(__package__ or __name__)
-
-# Set tmp dir for Windows
-__tmp_dir__: Optional[str] = None
-__tmp_codemeta_dir__: Optional[str] = None
-
-if platform.system() == "Windows":
-    # create temp folder
-    root_path = Path(__file__).parent.parent.parent
-    temp_folder = Path(f"{root_path.resolve()}//Temp")
-    temp_folder.mkdir(exist_ok=True)
-
-    # resolve temp folder to absolute path
-    resolved_temp_folder = str(temp_folder.resolve())
-    __tmp_dir__ = resolved_temp_folder
-    environ["TMPDIR"] = resolved_temp_folder
-
-    # create temp folder for codemeta
-    codemeta_folder = Path(f"{temp_folder}//codemeta")
-    codemeta_folder.mkdir(exist_ok=True)
-    __tmp_codemeta_dir__ = str(codemeta_folder.resolve())

--- a/src/somesy/__init__.py
+++ b/src/somesy/__init__.py
@@ -12,14 +12,20 @@ __version__: Final[str] = importlib_metadata.version(__package__ or __name__)
 
 # Set tmp dir for Windows
 __tmp_dir__: Optional[str] = None
+__tmp_codemeta_dir__: Optional[str] = None
 
 if platform.system() == "Windows":
     # create temp folder
-    driver_letter = Path(__file__).drive
-    temp_folder = Path(f"{driver_letter}//Temp")
-    temp_folder.mkdir(parents=True, exist_ok=True)
+    root_path = Path(__file__).parent.parent.parent
+    temp_folder = Path(f"{root_path.resolve()}//Temp")
+    temp_folder.mkdir(exist_ok=True)
 
     # resolve temp folder to absolute path
     resolved_temp_folder = str(temp_folder.resolve())
     __tmp_dir__ = resolved_temp_folder
     environ["TMPDIR"] = resolved_temp_folder
+
+    # create temp folder for codemeta
+    codemeta_folder = Path(f"{temp_folder}//codemeta")
+    codemeta_folder.mkdir(exist_ok=True)
+    __tmp_codemeta_dir__ = str(codemeta_folder.resolve())

--- a/src/somesy/__init__.py
+++ b/src/somesy/__init__.py
@@ -1,10 +1,11 @@
 """somesy package."""
-import importlib_metadata
-from typing import Optional
-from typing_extensions import Final
 import platform
-from pathlib import Path
 from os import environ
+from pathlib import Path
+from typing import Optional
+
+import importlib_metadata
+from typing_extensions import Final
 
 # Set version, it will use version from pyproject.toml if defined
 __version__: Final[str] = importlib_metadata.version(__package__ or __name__)

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -1,7 +1,7 @@
 """Integration with codemetapy (to re-generate codemeta as part of somesy sync)."""
 import contextlib
 import logging
-from pathlib import Path
+from pathlib import Path, WindowsPath, PureWindowsPath
 
 from ..core.models import SomesyConfig
 from .exec import gen_codemeta
@@ -44,7 +44,14 @@ def update_codemeta(conf: SomesyConfig):
     temp_cff_cm = contextlib.nullcontext(None)
     if not conf.no_sync_cff and conf.cff_file is not None:
         temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
-        cm_sources.append(Path(temp_cff_cm.name))
+        p = Path(temp_cff_cm.name)
+        if isinstance(p, WindowsPath):
+            # codemetapy does not support WindowsPath, so we convert it to PureWindowsPath
+            # (which is a subclass of PurePath, which is what codemetapy expects)
+            # NOTE: this is a workaround for codemetapy 2.5.1, which does not support WindowsPath
+            #       (it's fixed in 2.5.2, but that version is not yet available on PyPI)
+            p = PureWindowsPath(p)
+        cm_sources.append(p)
 
     # run codemetapy
     with temp_cff_cm:

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -48,7 +48,7 @@ def update_codemeta(conf: SomesyConfig):
     temp_cff_cm = contextlib.nullcontext(None)
     if not conf.no_sync_cff and conf.cff_file is not None:
         temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
-        cm_sources.append(str(Path(temp_cff_cm.name).resolve()))
+        cm_sources.append(Path(temp_cff_cm.name).resolve())
 
     # run codemetapy
     with temp_cff_cm:

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 from ..core.models import SomesyConfig
 from .exec import gen_codemeta
-from .utils import cff_codemeta_tempfile, update_codemeta_file
+from .utils import (
+    cff_codemeta_tempfile,
+    cleanup_codemeta_tempfiles,
+    update_codemeta_file,
+)
 
 log = logging.getLogger("somesy")
 
@@ -44,7 +48,7 @@ def update_codemeta(conf: SomesyConfig):
     temp_cff_cm = contextlib.nullcontext(None)
     if not conf.no_sync_cff and conf.cff_file is not None:
         temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
-        cm_sources.append("/" + str(Path(temp_cff_cm.name).resolve()))
+        cm_sources.append(str(Path(temp_cff_cm.name).resolve()))
 
     # run codemetapy
     with temp_cff_cm:
@@ -60,7 +64,11 @@ def update_codemeta(conf: SomesyConfig):
     #     f.write(json.dumps(cm_harvest, indent=4, ensure_ascii=False, sort_keys=True))
 
     # check output and write file if needed (with workaround checking graph equivalence)
-    return update_codemeta_file(conf.codemeta_file, cm_harvest)
+    result = update_codemeta_file(conf.codemeta_file, cm_harvest)
+
+    # cleanup
+    cleanup_codemeta_tempfiles()
+    return result
 
 
 __all__ = ["update_codemeta"]

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -1,7 +1,7 @@
 """Integration with codemetapy (to re-generate codemeta as part of somesy sync)."""
 import contextlib
 import logging
-from pathlib import Path, WindowsPath, PureWindowsPath
+from pathlib import Path
 
 from ..core.models import SomesyConfig
 from .exec import gen_codemeta
@@ -44,14 +44,7 @@ def update_codemeta(conf: SomesyConfig):
     temp_cff_cm = contextlib.nullcontext(None)
     if not conf.no_sync_cff and conf.cff_file is not None:
         temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
-        p = Path(temp_cff_cm.name)
-        if isinstance(p, WindowsPath):
-            # codemetapy does not support WindowsPath, so we convert it to PureWindowsPath
-            # (which is a subclass of PurePath, which is what codemetapy expects)
-            # NOTE: this is a workaround for codemetapy 2.5.1, which does not support WindowsPath
-            #       (it's fixed in 2.5.2, but that version is not yet available on PyPI)
-            p = PureWindowsPath(p)
-        cm_sources.append(p)
+        cm_sources.append(str(Path(temp_cff_cm.name).resolve()))
 
     # run codemetapy
     with temp_cff_cm:

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -1,7 +1,5 @@
 """Integration with codemetapy (to re-generate codemeta as part of somesy sync)."""
-import contextlib
 import logging
-from pathlib import Path
 
 from ..core.models import SomesyConfig
 from .exec import gen_codemeta
@@ -45,14 +43,12 @@ def update_codemeta(conf: SomesyConfig):
     cm_sources = collect_cm_sources(conf)
 
     # if cff file is given, convert it to codemeta tempfile and pass as extra input
-    temp_cff_cm = contextlib.nullcontext(None)
     if not conf.no_sync_cff and conf.cff_file is not None:
         temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
-        cm_sources.append(Path(temp_cff_cm.name).resolve())
+        cm_sources.append(temp_cff_cm.resolve())
 
     # run codemetapy
-    with temp_cff_cm:
-        cm_harvest = gen_codemeta(cm_sources)
+    cm_harvest = gen_codemeta(cm_sources)
 
     # NOTE: once codemetapy is fixed (still broken with 2.5.1), we should not need
     # update_codemeta_file + codemeta context dump + most of utils.py + their tests anymore

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -44,7 +44,7 @@ def update_codemeta(conf: SomesyConfig):
     temp_cff_cm = contextlib.nullcontext(None)
     if not conf.no_sync_cff and conf.cff_file is not None:
         temp_cff_cm = cff_codemeta_tempfile(conf.cff_file)
-        cm_sources.append(str(Path(temp_cff_cm.name).resolve()))
+        cm_sources.append("/" + str(Path(temp_cff_cm.name).resolve()))
 
     # run codemetapy
     with temp_cff_cm:

--- a/src/somesy/codemeta/__init__.py
+++ b/src/somesy/codemeta/__init__.py
@@ -60,7 +60,9 @@ def patch_codemetapy():
 
         def patched_init_context(*args, **kwargs):
             unfix_local_sources()
-            ret = [(fix(a), b) for a, b in init_context(*args, **kwargs)]
+            # NOTE: do not fix sources here, init_graph chokes on it
+            # ret = [(fix(a), b) for a, b in init_context(*args, **kwargs)]
+            ret = init_context(*args, **kwargs)
             fix_local_sources()
             return ret
 

--- a/src/somesy/codemeta/exec.py
+++ b/src/somesy/codemeta/exec.py
@@ -7,8 +7,72 @@ from pathlib import Path
 from typing import Dict, List
 
 from cffconvert.cli.create_citation import create_citation
-from codemeta.codemeta import build
-from codemeta.serializers.jsonld import serialize_to_jsonld
+
+# ----
+# TODO: remove this section once windows path issue is fixed
+_patched = False
+
+
+def patch_codemetapy():
+    """Monkey-patch for codemetapy (< 2.5.2)."""
+    global _patched
+    from importlib_metadata import version
+
+    if version("codemetapy") >= "2.5.2":
+        return
+
+    import codemeta.common as cmc
+
+    def fix(path: str) -> str:
+        """Ensure the windows file URI is valid (starts with file:///)."""
+        if path.startswith("file://") and not path.startswith("file:///"):
+            return path.replace("file://", "file:///")
+        return path
+
+    def unfix(path: str) -> str:
+        if path.startswith("file:///") and path[9] == ":":  # windows partition name
+            return path.replace("file:///", "file://")
+        return path
+
+    def fix_local_sources():
+        cmc.SCHEMA_LOCAL_SOURCE = fix(cmc.SCHEMA_LOCAL_SOURCE)
+        cmc.CODEMETA_LOCAL_SOURCE = fix(cmc.CODEMETA_LOCAL_SOURCE)
+        cmc.STYPE_LOCAL_SOURCE = fix(cmc.STYPE_LOCAL_SOURCE)
+        cmc.IODATA_LOCAL_SOURCE = fix(cmc.IODATA_LOCAL_SOURCE)
+        cmc.REPOSTATUS_LOCAL_SOURCE = fix(cmc.REPOSTATUS_LOCAL_SOURCE)
+
+    def unfix_local_sources():
+        cmc.SCHEMA_LOCAL_SOURCE = unfix(cmc.SCHEMA_LOCAL_SOURCE)
+        cmc.CODEMETA_LOCAL_SOURCE = unfix(cmc.CODEMETA_LOCAL_SOURCE)
+        cmc.STYPE_LOCAL_SOURCE = unfix(cmc.STYPE_LOCAL_SOURCE)
+        cmc.IODATA_LOCAL_SOURCE = unfix(cmc.IODATA_LOCAL_SOURCE)
+        cmc.REPOSTATUS_LOCAL_SOURCE = unfix(cmc.REPOSTATUS_LOCAL_SOURCE)
+
+    fix_local_sources()
+
+    if not _patched:
+        _patched = True
+
+        init_context = cmc.init_context
+
+        def patched_init_context(*args, **kwargs):
+            unfix_local_sources()
+            # NOTE: do not fix sources here, init_graph chokes on it
+            # ret = [(fix(a), b) for a, b in init_context(*args, **kwargs)]
+            ret = init_context(*args, **kwargs)
+            fix_local_sources()
+            return ret
+
+        cmc.init_context = patched_init_context
+
+
+if not _patched:
+    patch_codemetapy()
+# ----
+
+
+from codemeta.codemeta import build  # noqa
+from codemeta.serializers.jsonld import serialize_to_jsonld  # noqa
 
 log = logging.getLogger("somesy")
 

--- a/src/somesy/codemeta/exec.py
+++ b/src/somesy/codemeta/exec.py
@@ -8,6 +8,8 @@ from typing import Dict, List
 
 from cffconvert.cli.create_citation import create_citation
 
+log = logging.getLogger("somesy")
+
 # ----
 # TODO: remove this section once windows path issue is fixed
 _patched = False
@@ -56,6 +58,7 @@ def patch_codemetapy():
         init_context = cmc.init_context
 
         def patched_init_context(*args, **kwargs):
+            log.info("called patched init")
             unfix_local_sources()
             # NOTE: do not fix sources here, init_graph chokes on it
             # ret = [(fix(a), b) for a, b in init_context(*args, **kwargs)]
@@ -71,12 +74,6 @@ if not _patched:
 # ----
 
 
-from codemeta.codemeta import build  # noqa
-from codemeta.serializers.jsonld import serialize_to_jsonld  # noqa
-
-log = logging.getLogger("somesy")
-
-
 def cff_to_codemeta(cff_file: Path) -> Dict:
     """Get codemeta LD dict from CITATION.cff via cffconvert."""
     return json.loads(create_citation(cff_file, None).as_codemeta())
@@ -85,6 +82,10 @@ def cff_to_codemeta(cff_file: Path) -> Dict:
 def gen_codemeta(sources: List[str], *, with_entrypoints: bool = True) -> Dict:
     """Harvest codemeta LD dict via codemetapy."""
     log.debug(f"Running codemetapy with sources {sources}")
+
+    from codemeta.codemeta import build  # noqa
+    from codemeta.serializers.jsonld import serialize_to_jsonld  # noqa
+
     with redirect_stderr(StringIO()) as cm_log:
         g, res, args, _ = build(
             inputsources=list(map(str, sources)),

--- a/src/somesy/codemeta/exec.py
+++ b/src/somesy/codemeta/exec.py
@@ -23,6 +23,8 @@ def patch_codemetapy():
     if version("codemetapy") >= "2.5.2":
         return
 
+    log.info("patching codemeta")
+
     import codemeta.common as cmc
 
     def fix(path: str) -> str:

--- a/src/somesy/codemeta/exec.py
+++ b/src/somesy/codemeta/exec.py
@@ -14,6 +14,8 @@ log = logging.getLogger("somesy")
 # TODO: remove this section once windows path issue is fixed
 _patched = False
 
+import codemeta.common as cmc  # noqa
+
 
 def patch_codemetapy():
     """Monkey-patch for codemetapy (< 2.5.2)."""
@@ -24,8 +26,6 @@ def patch_codemetapy():
         return
 
     log.info("patching codemeta")
-
-    import codemeta.common as cmc
 
     def fix(path: str) -> str:
         """Ensure the windows file URI is valid (starts with file:///)."""


### PR DESCRIPTION
When somesy is run in a Windows environment, rdflib parsing creates problems because of the usage of temporary directories. I fixed this problem by using a direct C:/Temp folder when the OS is Windows. I added Windows and MacOS to our CI test matrix.