### PR TITLE
fix setuptools license model

### DIFF
--- a/src/somesy/pyproject/models.py
+++ b/src/somesy/pyproject/models.py
@@ -161,9 +161,7 @@ class SetuptoolsConfig(BaseModel):
     ]
     description: str
     readme: Optional[Union[Path, List[Path], File]] = None
-    license: Optional[License] = Field(
-        None, description="An SPDX license identifier."
-    )
+    license: Optional[License] = Field(None, description="An SPDX license identifier.")
     authors: Optional[List[STPerson]] = None
     maintainers: Optional[List[STPerson]] = None
     keywords: Optional[Set[str]] = None

--- a/src/somesy/pyproject/models.py
+++ b/src/somesy/pyproject/models.py
@@ -122,8 +122,8 @@ class License(BaseModel):
 
     model_config = dict(validate_assignment=True)
 
-    file: Optional[Path]
-    text: Optional[LicenseEnum]
+    file: Optional[Path] = None
+    text: Optional[LicenseEnum] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -161,7 +161,7 @@ class SetuptoolsConfig(BaseModel):
     ]
     description: str
     readme: Optional[Union[Path, List[Path], File]] = None
-    license: Optional[Union[LicenseEnum, List[LicenseEnum]]] = Field(
+    license: Optional[License] = Field(
         None, description="An SPDX license identifier."
     )
     authors: Optional[List[STPerson]] = None

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -9,7 +9,7 @@ import wrapt
 from rich.pretty import pretty_repr
 from tomlkit import load
 
-from somesy.core.models import Person
+from somesy.core.models import Person,ProjectMetadata
 from somesy.core.writer import ProjectMetadataWriter
 
 from .models import PoetryConfig, SetuptoolsConfig
@@ -122,6 +122,7 @@ class SetupTools(PyprojectCommon):
         mappings = {
             "homepage": ["urls", "homepage"],
             "repository": ["urls", "repository"],
+            "license": ["license", "text"],
         }
         super().__init__(
             path, section=section, direct_mappings=mappings, model_cls=SetuptoolsConfig
@@ -145,6 +146,17 @@ class SetupTools(PyprojectCommon):
                 "email": person_obj["email"].strip(),
             }
         )
+        
+    
+    def sync(self, metadata: ProjectMetadata) -> None:
+        """Sync metadata with pyproject.toml file and fix license field."""
+        super().sync(metadata)
+        
+        # if license field has both text and file, remove file
+        if self._get_property(["license", "file"]) is not None and self._get_property(["license", "text"]) is not None:
+            # delete license file property
+            self._data["project"]["license"].pop("file")
+            logger.debug("Removed license file from pyproject.toml")
 
 
 # ----

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -9,7 +9,7 @@ import wrapt
 from rich.pretty import pretty_repr
 from tomlkit import load
 
-from somesy.core.models import Person,ProjectMetadata
+from somesy.core.models import Person, ProjectMetadata
 from somesy.core.writer import ProjectMetadataWriter
 
 from .models import PoetryConfig, SetuptoolsConfig
@@ -146,14 +146,16 @@ class SetupTools(PyprojectCommon):
                 "email": person_obj["email"].strip(),
             }
         )
-        
-    
+
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync metadata with pyproject.toml file and fix license field."""
         super().sync(metadata)
-        
+
         # if license field has both text and file, remove file
-        if self._get_property(["license", "file"]) is not None and self._get_property(["license", "text"]) is not None:
+        if (
+            self._get_property(["license", "file"]) is not None
+            and self._get_property(["license", "text"]) is not None
+        ):
             # delete license file property
             self._data["project"]["license"].pop("file")
             logger.debug("Removed license file from pyproject.toml")

--- a/tests/data/pyproject.setuptools.toml
+++ b/tests/data/pyproject.setuptools.toml
@@ -2,8 +2,8 @@
 name = "test-package"
 version = "0.1.0"
 description = "This is a test package for demonstration purposes."
-authors = [{"name"="John Doe", "email"="john.doe@example.com"}]
-license = "MIT"
+authors = [{ "name" = "John Doe", "email" = "john.doe@example.com" }]
+license = { text = "MIT" }
 keywords = ["test", "demo", "example"]
 classifiers = [
     "Operating System :: POSIX :: Linux",

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -38,7 +38,7 @@ def test_content_match(pyproject_poetry, pyproject_setuptools):
             pyproject_file.description
             == "This is a test package for demonstration purposes."
         )
-        assert pyproject_file.license == "MIT"
+        assert pyproject_file.license == "MIT" or pyproject_file.license["text"] == "MIT"
         assert len(pyproject_file.authors) == 1
 
     # assert for both formats

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -38,7 +38,9 @@ def test_content_match(pyproject_poetry, pyproject_setuptools):
             pyproject_file.description
             == "This is a test package for demonstration purposes."
         )
-        assert pyproject_file.license == "MIT" or pyproject_file.license["text"] == "MIT"
+        assert (
+            pyproject_file.license == "MIT" or pyproject_file.license["text"] == "MIT"
+        )
         assert len(pyproject_file.authors) == 1
 
     # assert for both formats


### PR DESCRIPTION
Setuptools license model was not used in Setuptool pydantic class even though it was created. I fixed the model,  mappings, and test data accordingly. I also ran `pip install .` with the test data, which worked without problem after the update.
resolves #67 