### PR TITLE
update/fix validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,43 +4,50 @@ Here we provide notes that summarize the most important changes in each released
 
 Please consult the changelog to inform yourself about breaking changes and security issues.
 
+## [v0.4.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.4.3) <small>(2024-07-??)</small> { id="0.4.3" }
+
+-   update python dependencies
+-   update pre-commit hook versions
+-   fix package.json person validation
+-   update poetry, julia, and package.json person validation: entries without an email wont't raise an error, they will be ignored.
+
 ## [v0.4.2](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.4.2) <small>(2024-04-30)</small> { id="0.4.2" }
 
-* fix rich logging bug for error messages and tracebacks
+-   fix rich logging bug for error messages and tracebacks
 
 ## [v0.4.1](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.4.1) <small>(2024-04-08)</small> { id="0.4.1" }
 
-* fix package.json and mkdocs.yml validation bug about optional fields
+-   fix package.json and mkdocs.yml validation bug about optional fields
 
 ## [v0.4.0](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.4.0) <small>(2024-03-08)</small> { id="0.4.0" }
 
-* added separate `documentation` URL to Project metadata model
-* added support for Julia `Project.toml` file
-* added support for Fortran `fpm.toml` file
-* added support for Java `pom.xml` file
-* added support for MkDocs `mkdocs.yml` file
-* added support for Rust `Cargo.toml` file
+-   added separate `documentation` URL to Project metadata model
+-   added support for Julia `Project.toml` file
+-   added support for Fortran `fpm.toml` file
+-   added support for Java `pom.xml` file
+-   added support for MkDocs `mkdocs.yml` file
+-   added support for Rust `Cargo.toml` file
 
 ## [v0.3.1](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.3.1) <small>(2024-01-23)</small> { id="0.3.1" }
 
-* fix setuptools license writing bug
+-   fix setuptools license writing bug
 
 ## [v0.3.0](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.3.0) <small>(2024-01-12)</small> { id="0.3.0" }
 
-* replace codemetapy with an in-house writer, which enables windows support
+-   replace codemetapy with an in-house writer, which enables windows support
 
 ## [v0.2.1](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.2.1) <small>(2023-11-29)</small> { id="0.2.1" }
 
-* **internal:** updated linters and dependencies
-* **internal:** pin codemetapy version to 2.5.2 to avoid breaking changes
-* fix bug caused by missing `config` section
+-   **internal:** updated linters and dependencies
+-   **internal:** pin codemetapy version to 2.5.2 to avoid breaking changes
+-   fix bug caused by missing `config` section
 
 ## [v0.2.0](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.2.0) <small>(2023-11-29)</small> { id="0.2.0" }
 
-* **internal:** Test refactoring
-* **internal:** Pydantic 2 implementation
-* Added `publication_author` field to Person model
+-   **internal:** Test refactoring
+-   **internal:** Pydantic 2 implementation
+-   Added `publication_author` field to Person model
 
 ## [v0.1.0](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.1.0) <small>(2023-08-10)</small> { id="0.1.0" }
 
-* First release
+-   First release

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -331,7 +331,15 @@ class ProjectMetadataWriter(ABC):
     @property
     def authors(self):
         """Return the authors of the project."""
-        return self._get_property(self._get_key("authors"))
+        authors = self._get_property(self._get_key("authors"))
+        if authors is None:
+            return []
+
+        # only return authors that can be converted to Person
+        authors_validated = [
+            author for author in authors if self._to_person(author) is not None
+        ]
+        return authors_validated
 
     @authors.setter
     def authors(self, authors: List[Person]) -> None:
@@ -342,7 +350,17 @@ class ProjectMetadataWriter(ABC):
     @property
     def maintainers(self):
         """Return the maintainers of the project."""
-        return self._get_property(self._get_key("maintainers"))
+        maintainers = self._get_property(self._get_key("maintainers"))
+        if maintainers is None:
+            return []
+
+        # only return maintainers that can be converted to Person
+        maintainers_validated = [
+            maintainer
+            for maintainer in maintainers
+            if self._to_person(maintainer) is not None
+        ]
+        return maintainers_validated
 
     @maintainers.setter
     def maintainers(self, maintainers: List[Person]) -> None:

--- a/src/somesy/fortran/writer.py
+++ b/src/somesy/fortran/writer.py
@@ -90,7 +90,7 @@ class Fortran(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person_obj: Any) -> Person:
+    def _to_person(person_obj: Any) -> Optional[Person]:
         """Cannot convert from free string to person object."""
         try:
             return Person.from_name_email_string(person_obj)

--- a/src/somesy/fortran/writer.py
+++ b/src/somesy/fortran/writer.py
@@ -94,7 +94,7 @@ class Fortran(ProjectMetadataWriter):
         """Cannot convert from free string to person object."""
         try:
             return Person.from_name_email_string(person_obj)
-        except ValueError:
+        except (ValueError, AttributeError):
             logger.warning(f"Cannot convert {person_obj} to Person object.")
             return None
 

--- a/src/somesy/julia/models.py
+++ b/src/somesy/julia/models.py
@@ -1,6 +1,7 @@
 """Julia model."""
 
 import uuid
+from logging import getLogger
 from typing import Optional, Set
 
 from packaging.version import parse as parse_version
@@ -9,11 +10,13 @@ from pydantic import (
     EmailStr,
     Field,
     TypeAdapter,
+    ValidationError,
     field_validator,
 )
 from typing_extensions import Annotated
 
 EMailAddress = TypeAdapter(EmailStr)
+logger = getLogger("somesy")
 
 
 class JuliaConfig(BaseModel):
@@ -48,15 +51,25 @@ class JuliaConfig(BaseModel):
     @field_validator("authors")
     @classmethod
     def validate_email_format(cls, v):
-        """Validate email format."""
+        """Validate person format, omit person that is not in correct format, don't raise an error."""
+        if v is None:
+            return []
+        validated = []
         for author in v:
-            if (
-                not isinstance(author, str)
-                or " " not in author
-                or not EMailAddress.validate_python(author.split(" ")[-1][1:-1])
-            ):
-                raise ValueError("Invalid email format")
-        return v
+            try:
+                if not (
+                    not isinstance(author, str)
+                    or " " not in author
+                    or not EMailAddress.validate_python(author.split(" ")[-1][1:-1])
+                ):
+                    validated.append(author)
+                else:
+                    logger.warning(
+                        f"Invalid email format for author {author}, omitting."
+                    )
+            except ValidationError:
+                logger.warning(f"Invalid format for author {author}, omitting.")
+        return validated
 
     @field_validator("uuid")
     @classmethod

--- a/src/somesy/julia/writer.py
+++ b/src/somesy/julia/writer.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import tomlkit
 from rich.pretty import pretty_repr
@@ -57,6 +57,52 @@ class Julia(ProjectMetadataWriter):
     def _to_person(person_obj: str) -> Person:
         """Parse name+email string to a Person."""
         return Person.from_name_email_string(person_obj)
+
+    @property
+    def authors(self) -> List[str]:
+        """Get authors from the pyproject.toml file."""
+        # check if authors can be converted to person, only return valid ones
+        authors = self._get_property("authors")
+        if authors is None:
+            return []
+
+        valid_authors = []
+        for author in authors:
+            try:
+                self._to_person(author)
+                valid_authors.append(author)
+            except (ValueError, AttributeError):
+                logger.warning(f"Invalid author format: {author}")
+        return valid_authors
+
+    @authors.setter
+    def authors(self, authors: List[Person]) -> None:
+        """Set the authors of the project."""
+        authors = [self._from_person(c) for c in authors]
+        self._set_property(self._get_key("authors"), authors)
+
+    @property
+    def maintainers(self) -> List[str]:
+        """Get maintainers from the pyproject.toml file."""
+        # check if maintainers can be converted to person, only return valid ones
+        maintainers = self._get_property("maintainers")
+        if maintainers is None:
+            return []
+
+        valid_maintainers = []
+        for maintainer in maintainers:
+            try:
+                self._to_person(maintainer)
+                valid_maintainers.append(maintainer)
+            except (ValueError, AttributeError):
+                logger.warning(f"Invalid maintainer format: {maintainer}")
+        return valid_maintainers
+
+    @maintainers.setter
+    def maintainers(self, maintainers: List[Person]) -> None:
+        """Set the maintainers of the project."""
+        maintainers = [self._from_person(c) for c in maintainers]
+        self._set_property(self._get_key("maintainers"), maintainers)
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync output file with other metadata files."""

--- a/src/somesy/julia/writer.py
+++ b/src/somesy/julia/writer.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import tomlkit
 from rich.pretty import pretty_repr
@@ -54,55 +54,13 @@ class Julia(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person_obj: str) -> Person:
+    def _to_person(person_obj) -> Optional[Person]:
         """Parse name+email string to a Person."""
-        return Person.from_name_email_string(person_obj)
-
-    @property
-    def authors(self) -> List[str]:
-        """Get authors from the pyproject.toml file."""
-        # check if authors can be converted to person, only return valid ones
-        authors = self._get_property("authors")
-        if authors is None:
-            return []
-
-        valid_authors = []
-        for author in authors:
-            try:
-                self._to_person(author)
-                valid_authors.append(author)
-            except (ValueError, AttributeError):
-                logger.warning(f"Invalid author format: {author}")
-        return valid_authors
-
-    @authors.setter
-    def authors(self, authors: List[Person]) -> None:
-        """Set the authors of the project."""
-        authors = [self._from_person(c) for c in authors]
-        self._set_property(self._get_key("authors"), authors)
-
-    @property
-    def maintainers(self) -> List[str]:
-        """Get maintainers from the pyproject.toml file."""
-        # check if maintainers can be converted to person, only return valid ones
-        maintainers = self._get_property("maintainers")
-        if maintainers is None:
-            return []
-
-        valid_maintainers = []
-        for maintainer in maintainers:
-            try:
-                self._to_person(maintainer)
-                valid_maintainers.append(maintainer)
-            except (ValueError, AttributeError):
-                logger.warning(f"Invalid maintainer format: {maintainer}")
-        return valid_maintainers
-
-    @maintainers.setter
-    def maintainers(self, maintainers: List[Person]) -> None:
-        """Set the maintainers of the project."""
-        maintainers = [self._from_person(c) for c in maintainers]
-        self._set_property(self._get_key("maintainers"), maintainers)
+        try:
+            return Person.from_name_email_string(person_obj)
+        except (ValueError, AttributeError):
+            logger.warning(f"Cannot convert {person_obj} to Person object.")
+            return None
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync output file with other metadata files."""

--- a/src/somesy/mkdocs/writer.py
+++ b/src/somesy/mkdocs/writer.py
@@ -62,13 +62,11 @@ class MkDocs(ProjectMetadataWriter):
     @property
     def authors(self):
         """Return the only author from the source file as list."""
-        authors = []
-        try:
-            self._to_person(self._get_property(self._get_key("authors")))
-            authors = [self._get_property(self._get_key("authors"))]
-        except AttributeError:
-            logger.warning("Cannot convert authors to Person object.")
-        return authors
+        authors = self._get_property(self._get_key("authors"))
+        if authors is None or self._to_person(authors) is None:
+            return []
+        else:
+            return [authors]
 
     @authors.setter
     def authors(self, authors: List[Person]) -> None:
@@ -82,9 +80,13 @@ class MkDocs(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person: str):
+    def _to_person(person: str) -> Optional[Person]:
         """MkDocs Person is a string with full name."""
-        return Person.from_name_email_string(person)
+        try:
+            return Person.from_name_email_string(person)
+        except (ValueError, AttributeError):
+            logger.warning(f"Cannot convert {person} to Person object.")
+            return None
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync the MkDocs object with the ProjectMetadata object."""

--- a/src/somesy/package_json/writer.py
+++ b/src/somesy/package_json/writer.py
@@ -35,6 +35,12 @@ class PackageJSON(ProjectMetadataWriter):
     @property
     def authors(self):
         """Return the only author of the package.json file as list."""
+        # check if the author has the correct format
+        if isinstance(author := self._get_property(self._get_key("authors")), str):
+            author = PackageJsonConfig.convert_author(author)
+            if author is None:
+                return []
+
         return [self._get_property(self._get_key("authors"))]
 
     @authors.setter
@@ -44,9 +50,48 @@ class PackageJSON(ProjectMetadataWriter):
         self._set_property(self._get_key("authors"), authors)
 
     @property
+    def maintainers(self):
+        """Return the maintainers of the package.json file."""
+        # check if the maintainer has the correct format
+        maintainers = self._get_property(self._get_key("maintainers"))
+        # return empty list if maintainers is None
+        if maintainers is None:
+            return []
+
+        maintainers_valid = []
+
+        for maintainer in maintainers:
+            if isinstance(maintainer, str):
+                maintainer = PackageJsonConfig.convert_author(maintainer)
+                if maintainer is None:
+                    continue
+            maintainers_valid.append(maintainer)
+        return maintainers_valid
+
+    @maintainers.setter
+    def maintainers(self, maintainers: List[Person]) -> None:
+        """Set the maintainers of the project."""
+        maintainers = [self._from_person(m) for m in maintainers]
+        self._set_property(self._get_key("maintainers"), maintainers)
+
+    @property
     def contributors(self):
         """Return the contributors of the package.json file."""
-        return self._get_property(self._get_key("contributors"))
+        # check if the contributor has the correct format
+        contributors = self._get_property(self._get_key("contributors"))
+        # return empty list if contributors is None
+        if contributors is None:
+            return []
+
+        contributors_valid = []
+
+        for contributor in contributors:
+            if isinstance(contributor, str):
+                contributor = PackageJsonConfig.convert_author(contributor)
+                if contributor is None:
+                    continue
+            contributors_valid.append(contributor)
+        return contributors_valid
 
     @contributors.setter
     def contributors(self, contributors: List[Person]) -> None:
@@ -91,9 +136,12 @@ class PackageJSON(ProjectMetadataWriter):
         """Convert package.json dict or str for person format to project metadata person object."""
         if isinstance(person, str):
             # parse from package.json format
-            person = PackageJsonConfig.convert_author(person).model_dump(
-                exclude_none=True
-            )
+            person = PackageJsonConfig.convert_author(person)
+
+            if person is None:
+                return None
+
+            person = person.model_dump(exclude_none=True)
 
         names = list(map(lambda s: s.strip(), person["name"].split()))
         person_obj = {

--- a/src/somesy/pyproject/models.py
+++ b/src/somesy/pyproject/models.py
@@ -1,6 +1,7 @@
 """Pyproject models."""
 
 from enum import Enum
+from logging import getLogger
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
@@ -10,6 +11,7 @@ from pydantic import (
     EmailStr,
     Field,
     TypeAdapter,
+    ValidationError,
     field_validator,
     model_validator,
 )
@@ -19,6 +21,7 @@ from somesy.core.models import LicenseEnum
 from somesy.core.types import HttpUrlStr
 
 EMailAddress = TypeAdapter(EmailStr)
+logger = getLogger("somesy")
 
 
 class PoetryConfig(BaseModel):
@@ -81,15 +84,27 @@ class PoetryConfig(BaseModel):
     @field_validator("authors", "maintainers")
     @classmethod
     def validate_email_format(cls, v):
-        """Validate email format."""
+        """Validate person format, omit person that is not in correct format, don't raise an error."""
+        if v is None:
+            return []
+        validated = []
         for author in v:
-            if (
-                not isinstance(author, str)
-                or " " not in author
-                or not EMailAddress.validate_python(author.split(" ")[-1][1:-1])
-            ):
-                raise ValueError("Invalid email format")
-        return v
+            try:
+                if not (
+                    not isinstance(author, str)
+                    or " " not in author
+                    or not EMailAddress.validate_python(author.split(" ")[-1][1:-1])
+                ):
+                    validated.append(author)
+                else:
+                    logger.warning(
+                        f"Invalid email format for author/maintainer {author}, omitting."
+                    )
+            except ValidationError:
+                logger.warning(
+                    f"Invalid email format for author/maintainer {author}, omitting."
+                )
+        return validated
 
     @field_validator("readme")
     @classmethod
@@ -97,10 +112,10 @@ class PoetryConfig(BaseModel):
         """Validate readme file(s) by checking whether files exist."""
         if isinstance(v, list):
             if any(not e.is_file() for e in v):
-                raise ValueError("Some file(s) do not exist")
+                logger.warning("Some readme file(s) do not exist")
         else:
             if not v.is_file():
-                raise ValueError("File does not exist")
+                logger.warning("Readme file does not exist")
 
 
 class ContentTypeEnum(Enum):

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -96,61 +96,19 @@ class Poetry(PyprojectCommon):
         """
         super().__init__(path, section=["tool", "poetry"], model_cls=PoetryConfig)
 
-    @property
-    def authors(self) -> List[str]:
-        """Get authors from the pyproject.toml file."""
-        # check if authors can be converted to person, only return valid ones
-        authors = self._get_property("authors")
-        if authors is None:
-            return []
-
-        valid_authors = []
-        for author in authors:
-            try:
-                self._to_person(author)
-                valid_authors.append(author)
-            except (ValueError, AttributeError):
-                logger.warning(f"Invalid author format: {author}")
-        return valid_authors
-
-    @authors.setter
-    def authors(self, authors: List[Person]) -> None:
-        """Set the authors of the project."""
-        authors = [self._from_person(c) for c in authors]
-        self._set_property(self._get_key("authors"), authors)
-
-    @property
-    def maintainers(self) -> List[str]:
-        """Get maintainers from the pyproject.toml file."""
-        # check if maintainers can be converted to person, only return valid ones
-        maintainers = self._get_property("maintainers")
-        if maintainers is None:
-            return []
-
-        valid_maintainers = []
-        for maintainer in maintainers:
-            try:
-                self._to_person(maintainer)
-                valid_maintainers.append(maintainer)
-            except (ValueError, AttributeError):
-                logger.warning(f"Invalid maintainer format: {maintainer}")
-        return valid_maintainers
-
-    @maintainers.setter
-    def maintainers(self, maintainers: List[Person]) -> None:
-        """Set the maintainers of the project."""
-        maintainers = [self._from_person(c) for c in maintainers]
-        self._set_property(self._get_key("maintainers"), maintainers)
-
     @staticmethod
     def _from_person(person: Person):
         """Convert project metadata person object to poetry string for person format "full name <email>."""
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person_obj: str) -> Person:
+    def _to_person(person_obj: str) -> Optional[Person]:
         """Parse poetry person string to a Person."""
-        return Person.from_name_email_string(person_obj)
+        try:
+            return Person.from_name_email_string(person_obj)
+        except (ValueError, AttributeError):
+            logger.warning(f"Cannot convert {person_obj} to Person object.")
+            return None
 
 
 class SetupTools(PyprojectCommon):

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -96,6 +96,52 @@ class Poetry(PyprojectCommon):
         """
         super().__init__(path, section=["tool", "poetry"], model_cls=PoetryConfig)
 
+    @property
+    def authors(self) -> List[str]:
+        """Get authors from the pyproject.toml file."""
+        # check if authors can be converted to person, only return valid ones
+        authors = self._get_property("authors")
+        if authors is None:
+            return []
+
+        valid_authors = []
+        for author in authors:
+            try:
+                self._to_person(author)
+                valid_authors.append(author)
+            except (ValueError, AttributeError):
+                logger.warning(f"Invalid author format: {author}")
+        return valid_authors
+
+    @authors.setter
+    def authors(self, authors: List[Person]) -> None:
+        """Set the authors of the project."""
+        authors = [self._from_person(c) for c in authors]
+        self._set_property(self._get_key("authors"), authors)
+
+    @property
+    def maintainers(self) -> List[str]:
+        """Get maintainers from the pyproject.toml file."""
+        # check if maintainers can be converted to person, only return valid ones
+        maintainers = self._get_property("maintainers")
+        if maintainers is None:
+            return []
+
+        valid_maintainers = []
+        for maintainer in maintainers:
+            try:
+                self._to_person(maintainer)
+                valid_maintainers.append(maintainer)
+            except (ValueError, AttributeError):
+                logger.warning(f"Invalid maintainer format: {maintainer}")
+        return valid_maintainers
+
+    @maintainers.setter
+    def maintainers(self, maintainers: List[Person]) -> None:
+        """Set the maintainers of the project."""
+        maintainers = [self._from_person(c) for c in maintainers]
+        self._set_property(self._get_key("maintainers"), maintainers)
+
     @staticmethod
     def _from_person(person: Person):
         """Convert project metadata person object to poetry string for person format "full name <email>."""

--- a/src/somesy/rust/writer.py
+++ b/src/somesy/rust/writer.py
@@ -89,7 +89,7 @@ class Rust(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person_obj: str) -> Person:
+    def _to_person(person_obj: str) -> Optional[Person]:
         """Parse rust person string to a Person. It has format "full name <email>." but email is optional."""
         try:
             return Person.from_name_email_string(person_obj)

--- a/tests/output/test_julia_writer.py
+++ b/tests/output/test_julia_writer.py
@@ -115,3 +115,37 @@ def test_person_merge(request, julia_file, person):
     assert len(pj.authors) == 2
     assert pj.authors[0] == person1c_rep
     assert pj.authors[1] == person3_rep
+
+
+def test_without_email(tmp_path, person):
+    project_toml_str = """
+        name = "test-package"
+        version = "0.1.0"
+        authors = ["Jane Doe"]
+        uuid = "608dde89-f1f1-4a1a-863e-3c5da0c9a9e3"
+    """
+    # save to file
+    project_file = tmp_path / Path("Project.toml")
+    project_file.write_text(project_toml_str)
+
+    # load and sync
+    pj = Julia(project_file)
+
+    assert len(pj.authors) == 0
+
+    pm = ProjectMetadata(
+        name="My awesome project",
+        description="Project description",
+        license=LicenseEnum.MIT,
+        version="0.1.0",
+        people=[
+            person.model_copy(
+                update=dict(author=True, publication_author=True, maintainer=True)
+            )
+        ],
+    )
+
+    pj.sync(pm)
+
+    assert len(pj.authors) == 1
+    assert pj.authors[0] == f"{person.full_name} <{person.email}>"

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -77,8 +77,9 @@ def test_from_to_person(person):
     assert p.full_name == person.full_name
     assert p.email == person.email
 
-    with pytest.raises(AttributeError):
-        p = Poetry._to_person("John Doe")
+    # this should return None since there is no email
+    p = Poetry._to_person("John Doe")
+    assert p is None
 
     # test for setuptools
     assert SetupTools._from_person(person) == {

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -77,6 +77,9 @@ def test_from_to_person(person):
     assert p.full_name == person.full_name
     assert p.email == person.email
 
+    with pytest.raises(AttributeError):
+        p = Poetry._to_person("John Doe")
+
     # test for setuptools
     assert SetupTools._from_person(person) == {
         "name": person.full_name,
@@ -165,3 +168,47 @@ def test_person_merge_pyproject(request, writer_class, writer_file_fixture, pers
     assert len(pj.maintainers) == 1
     assert pj.authors[0] == person1c_rep
     assert pj.authors[1] == person3_rep
+
+
+def test_without_email(tmp_path, person):
+    pyproject_str = """
+    [tool.poetry]
+    name = "ttt"
+    version = "0.1.0"
+    description = "asd"
+    authors = ["John Doe"]
+    license = "MIT"
+
+    [tool.poetry.dependencies]
+    python = "^3.10"
+
+
+    [build-system]
+    requires = ["poetry-core"]
+    build-backend = "poetry.core.masonry.api"
+    """
+
+    # save to file
+    pyproject_file = tmp_path / Path("pyproject.toml")
+    pyproject_file.write_text(pyproject_str)
+
+    # load and sync
+    p = Poetry(pyproject_file)
+    assert len(p.authors) == 0
+
+    pm = ProjectMetadata(
+        name="My awesome project",
+        description="Project description",
+        license=LicenseEnum.MIT,
+        version="0.1.0",
+        people=[
+            person.model_copy(
+                update=dict(author=True, publication_author=True, maintainer=True)
+            )
+        ],
+    )
+
+    p.sync(pm)
+
+    assert len(p.authors) == 1
+    assert len(p.maintainers) == 1


### PR DESCRIPTION
Update poetry, package.json and julia models and writer for person validation. Now, we dont raise an error when the person doesnt have email information, we ignore that input and print a warning message. This also fixes #87 

closes #87 