### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ publication_author = true
 verbose = true     # show detailed information about what somesy is doing
 ```
 
+As Helmholtz Metadata Collaboration(HMC), our goal is to increase usage of metadata and improve metadata quality. Therefore, we set some fields in `somesy.toml` as compulsory fields to increase the metadata quality in the software projects `somesy` is used.
+
 <!-- --8<-- [end:somesytoml] -->
 
 Alternatively, you can also add the somesy configuration to an existing

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ latest stable version of somesy from PyPI using `pip`:
 pip install somesy
 ```
 
+> **Note**
+>
+> If you use somesy as a pre-commit hook, you don't have to install somesy on your PC nor add it as a dependency in your Python project. Pre-commit will handle the installation automatically.
+
 ### Configuring somesy
 
 Yes, somesy is _another_ tool with its own configuration. However, for your
@@ -163,6 +167,10 @@ repos:
     hooks:
       - id: somesy
 ```
+
+> **Note**
+>
+> Please add the latest version of Somesy to your project. You can update the version of Somesy in your config file now and later to use the newest versions as they become available.
 
 Note that `pre-commit` gives `somesy` the [staged](https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F) version of files,
 so when using `somesy` with pre-commit, keep in mind that

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ publication_author = true
 verbose = true     # show detailed information about what somesy is doing
 ```
 
-As Helmholtz Metadata Collaboration(HMC), our goal is to increase usage of metadata and improve metadata quality. Therefore, we set some fields in `somesy.toml` as compulsory fields to increase the metadata quality in the software projects `somesy` is used.
+As Helmholtz Metadata Collaboration (HMC), our goal is to increase usage of metadata and improve metadata quality. Therefore, some fields in `somesy.toml` are set as required fields. This is to increase rigour and completeness of metadata recorded with `somesy` .
 
 <!-- --8<-- [end:somesytoml] -->
 


### PR DESCRIPTION
After talking with some of our users, I wanted to update the documentation in several places.

1. Set a note explaining they don't have to install somesy to their PC or add it as a dependency if they use it as a pre-commit hook.
2. fix the version to the latest in the `somesy.toml`  example
3. add a note to warn users of the latest version 
4. explain why we set some fields as compulsory fields

When setting `somesy` up in the prototyping phase, we discussed the compulsory fields with Anton. It is not much, and a project should have at least that much metadata in its repository, else somesy doesn't mean anything anyway. However, we can discuss whether we should change the current compulsory fields.

Compulsory fields for project metadata:
- name
- description
- version
- license
- people: at least 1 person

Compulsory fields for project metadata:
- email
- family names
- given names