### PR TITLE
Support multiple licenses and modernize pyproject license output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,14 +55,14 @@ repos:
           # NOTE: copy from .pre-commit-hooks.yaml, for technical reasons
           - id: somesy-sync
             name: Run somesy sync
-            entry: somesy sync
-            language: python
+            entry: poetry run somesy sync
+            language: system
             files: '^\.somesy\.toml|pyproject\.toml$'
             pass_filenames: false
 
           - id: somesy-fill
             name: Update AUTHORS.md
-            entry: somesy fill -t docs/_template_authors.md -o AUTHORS.md
-            language: python
+            entry: poetry run somesy fill -t docs/_template_authors.md -o AUTHORS.md
+            language: system
             files: '^\.somesy\.toml|pyproject\.toml$'
             pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 - fix dependency vulnerabilities and replace Safety with pip-audit
 - modernize CI workflows and publish releases directly from CI
 - remove obsolete GitLab configuration and release workflows
+- support multiple SPDX licenses and modernize pyproject license output
 
 ## [v0.7.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.7.3) <small>(2025-03-14)</small> { id="0.7.3" }
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,7 @@ title: somesy
 version: 0.8.0a3
 abstract: A CLI tool for synchronizing software project metadata.
 url: https://materials-data-science-and-informatics.github.io/somesy
-repository-code: 
-  https://github.com/Materials-Data-Science-and-Informatics/somesy
+repository-code: https://github.com/Materials-Data-Science-and-Informatics/somesy
 license: MIT
 keywords:
   - metadata

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,8 @@ title: somesy
 version: 0.8.0a3
 abstract: A CLI tool for synchronizing software project metadata.
 url: https://materials-data-science-and-informatics.github.io/somesy
-repository-code: https://github.com/Materials-Data-Science-and-Informatics/somesy
+repository-code: 
+  https://github.com/Materials-Data-Science-and-Informatics/somesy
 license: MIT
 keywords:
   - metadata

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ version = "0.1.0"
 description = "Brief description of my amazing software."
 
 keywords = ["some", "descriptive", "keywords"]
-license = "MIT"
+license = ["MIT", "Apache-2.0"]
 repository = "https://github.com/username/my-amazing-project"
 
 # This is you, the proud author of your project:
@@ -215,7 +215,7 @@ Here is an overview of all the currently supported files and formats.
 1. note that `somesy` does not support setuptools or poetry _dynamic fields_
 2. `package.json` only supports one author, so `somesy` will pick the _first_ listed author
 3. `fpm.toml` only supports one author and maintainer, so `somesy` will pick the _first_ listed author and maintainer
-4. `pom.xml` has no concept of `maintainers`, but it can have multiple licenses (somesy only supports one main project license)
+4. `pom.xml` has no concept of `maintainers`, but it can have multiple licenses
 5. `mkdocs.yml` is a bit special, as it is not a project file, but a documentation file. `somesy` will only update it if it exists and is enabled in the configuration
 6. For handling `codemeta.json` different options exists: Either (A) `somesy` removes any prior existing `codemata.json` files and re-creates it anew, or (B) `somesy` merges an existing `codemeta.json` with the information handled by `somesy`. See the [user manual](https://materials-data-science-and-informatics.github.io/somesy/main/manual/#codemeta) for additional details about CodeMeta handling.
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -236,8 +236,10 @@ one of the supported input formats:
     description = "Brief description of my amazing software."
 
     keywords = ["some", "descriptive", "keywords"]
-    license = "MIT"
+    license = ["MIT", "Apache-2.0"]
     repository = "https://github.com/username/my-amazing-project"
+
+    # Multiple licenses are supported; single-value targets use the first one.
 
     # This is you, the proud author of your project
     [[tool.somesy.project.people]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,8 @@ authors = [
 maintainers = [
     {name = "Mustafa Soylu", email = "m.soylu@fz-juelich.de"},
 ]
+license = "MIT"
 
-
-[project.license]
-text = "MIT"
 
 [project.urls]
 homepage = "https://materials-data-science-and-informatics.github.io/somesy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ maintainers = [
     {name = "Mustafa Soylu", email = "m.soylu@fz-juelich.de"},
 ]
 
-[project.license]
-text = "MIT"
+license = "MIT"
 
 [project.urls]
 homepage = "https://materials-data-science-and-informatics.github.io/somesy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ maintainers = [
     {name = "Mustafa Soylu", email = "m.soylu@fz-juelich.de"},
 ]
 
-license = "MIT"
+
+[project.license]
+text = "MIT"
 
 [project.urls]
 homepage = "https://materials-data-science-and-informatics.github.io/somesy"

--- a/src/somesy/cff/writer.py
+++ b/src/somesy/cff/writer.py
@@ -27,6 +27,7 @@ class CFF(ProjectMetadataWriter):
         self._yaml = YAML()
         self._yaml.preserve_quotes = True
         self._yaml.indent(mapping=2, sequence=4, offset=2)
+        self._yaml.width = 120
 
         mappings: FieldKeyMapping = {
             "name": ["title"],

--- a/src/somesy/codemeta/writer.py
+++ b/src/somesy/codemeta/writer.py
@@ -147,7 +147,11 @@ class CodeMeta(ProjectMetadataWriter):
 
         # set license
         if "license" in data:
-            data["license"] = (f"https://spdx.org/licenses/{data['license']}",)
+            licenses = data["license"]
+            licenses = licenses if isinstance(licenses, list) else [licenses]
+            data["license"] = [
+                f"https://spdx.org/licenses/{license}" for license in licenses
+            ]
 
         # if softwareHelp is set, set url to softwareHelp
         if "softwareHelp" in data:
@@ -240,6 +244,12 @@ class CodeMeta(ProjectMetadataWriter):
         Use existing sync function from ProjectMetadataWriter but update repository and contributors.
         """
         super().sync(metadata)
+        licenses = metadata.license
+        self.license = (
+            [license.value for license in licenses]
+            if isinstance(licenses, list)
+            else licenses.value
+        )
         self.contributors = metadata.contributors()
 
         # add the default context items if they are not already in the codemeta.json file

--- a/src/somesy/commands/sync.py
+++ b/src/somesy/commands/sync.py
@@ -1,6 +1,7 @@
 """Sync selected metadata files with given input file."""
 
 import logging
+from copy import deepcopy
 from pathlib import Path
 
 from rich.pretty import pretty_repr
@@ -37,9 +38,11 @@ def _sync_file(
     else:
         writer = writer_cls(file, pass_validation=pass_validation)
     logger.verbose(f"Syncing '{file.name}' ...")
+    original_data = deepcopy(writer._data)
     writer.sync(metadata)
-    writer.save(file)
-    logger.verbose(f"Saved synced '{file.name}'.\n")
+    if writer._data != original_data:
+        writer.save(file)
+        logger.verbose(f"Saved synced '{file.name}'.\n")
 
 
 def _sync_files(

--- a/src/somesy/core/models.py
+++ b/src/somesy/core/models.py
@@ -704,7 +704,18 @@ class ProjectMetadata(SomesyBaseModel):
     name: Annotated[str, Field(description="Project name.")]
     description: Annotated[str, Field(description="Project description.")]
     version: Annotated[str | None, Field(description="Project version.")] = None
-    license: Annotated[LicenseEnum, Field(description="SPDX License string.")]
+    license: Annotated[
+        LicenseEnum | list[LicenseEnum],
+        Field(description="SPDX License string(s)."),
+    ]
+
+    @field_validator("license")
+    @classmethod
+    def validate_license_list(cls, license):
+        """Require at least one license when licenses are provided as a list."""
+        if isinstance(license, list) and not license:
+            raise ValueError("At least one license must be provided.")
+        return license
 
     homepage: Annotated[
         HttpUrlStr | None, Field(description="URL of the project homepage.")

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -431,12 +431,12 @@ class ProjectMetadataWriter(ABC):
         self._set_property(self._get_key("keywords"), keywords)
 
     @property
-    def license(self) -> str | None:
+    def license(self) -> str | list[str] | None:
         """Return the license of the project."""
         return self._get_property(self._get_key("license"))
 
     @license.setter
-    def license(self, license: str | None) -> None:
+    def license(self, license: str | list[str] | None) -> None:
         """Set the license of the project."""
         self._set_property(self._get_key("license"), license)
 

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -302,7 +302,10 @@ class ProjectMetadataWriter(ABC):
             self.maintainers, metadata.maintainers()
         )
 
-        self.license = metadata.license.value
+        licenses = metadata.license
+        self.license = (
+            licenses[0].value if isinstance(licenses, list) else licenses.value
+        )
 
         self.homepage = str(metadata.homepage) if metadata.homepage else None
         self.repository = str(metadata.repository) if metadata.repository else None

--- a/src/somesy/fortran/writer.py
+++ b/src/somesy/fortran/writer.py
@@ -155,6 +155,11 @@ class Fortran(ProjectMetadataWriter):
             # only one maintainer is allowed
             self.maintainers = maintainers
 
-        self.license = metadata.license.value
+        licenses = metadata.license
+        self.license = (
+            " OR ".join(license.value for license in licenses)
+            if isinstance(licenses, list)
+            else licenses.value
+        )
 
         self.homepage = str(metadata.homepage) if metadata.homepage else None

--- a/src/somesy/pom_xml/writer.py
+++ b/src/somesy/pom_xml/writer.py
@@ -189,18 +189,23 @@ class POM(ProjectMetadataWriter):
     def maintainers(self, maintainers: list[Person]) -> None:
         """Set the maintainers of the project."""
 
-    # only one project license supported in somesy (POM can have many)
     @property
-    def license(self) -> str | None:
+    def license(self) -> str | list[str] | None:
         """Return the license of the project."""
-        lic = self._get_property(self._get_key("license"), only_first=True)
-        return lic.get("name") if lic is not None else None
+        licenses = self._get_property(self._get_key("license"))
+        if licenses is None:
+            return None
+        licenses = licenses if isinstance(licenses, list) else [licenses]
+        names = [license["name"] for license in licenses]
+        return names[0] if len(names) == 1 else names
 
     @license.setter
-    def license(self, license: str | None) -> None:
+    def license(self, license: str | list[str] | None) -> None:
         """Set the license of the project."""
+        licenses = license if isinstance(license, list) else [license]
         self._set_property(
-            self._get_key("license"), {"name": license, "distribution": "repo"}
+            self._get_key("license"),
+            [{"name": license, "distribution": "repo"} for license in licenses],
         )
 
     @property
@@ -239,4 +244,10 @@ class POM(ProjectMetadataWriter):
         Use existing sync function from ProjectMetadataWriter but update repository and contributors.
         """
         super().sync(metadata)
+        licenses = metadata.license
+        self.license = (
+            [license.value for license in licenses]
+            if isinstance(licenses, list)
+            else licenses.value
+        )
         self.contributors = self._sync_person_list(self.contributors, metadata.people)

--- a/src/somesy/pyproject/models.py
+++ b/src/somesy/pyproject/models.py
@@ -85,7 +85,7 @@ class PoetryConfig(BaseModel):
     ]
     description: Annotated[str, Field(description="Package description")]
     license: Annotated[
-        LicenseEnum | list[LicenseEnum] | License | None,
+        LicenseEnum | list[LicenseEnum] | License | str | None,
         Field(description="An SPDX license identifier."),
     ]
 
@@ -207,7 +207,9 @@ class SetuptoolsConfig(BaseModel):
     ]
     description: str
     readme: Path | list[Path] | File | None = None
-    license: License | None = Field(None, description="An SPDX license identifier.")
+    license: License | LicenseEnum | str | None = Field(
+        None, description="An SPDX license identifier."
+    )
     authors: list[STPerson] | None = None
     maintainers: list[STPerson] | None = None
     keywords: set[str] | None = None

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -17,6 +17,11 @@ from .models import License, PoetryConfig, SetuptoolsConfig
 logger = logging.getLogger("somesy")
 
 
+def license_expression(licenses) -> str:
+    """Convert one or more license identifiers to an SPDX expression."""
+    return " OR ".join(str(license) for license in (licenses if isinstance(licenses, list) else [licenses]))
+
+
 class PyprojectCommon(ProjectMetadataWriter):
     """Poetry config file handler parsed from pyproject.toml."""
 
@@ -192,7 +197,7 @@ class Poetry(PyprojectCommon):
         if raw_license is None:
             return None
         if isinstance(raw_license, str):
-            return License(text=raw_license)
+            return raw_license
         return raw_license
 
     @license.setter
@@ -202,11 +207,7 @@ class Poetry(PyprojectCommon):
         if self._poetry_version == 1:
             self._set_property(["license"], value)
         else:
-            # if version is 2 and str, set as text
-            if isinstance(value, str):
-                self._set_property(["license"], {"text": value})
-            else:
-                self._set_property(["license"], value)
+            self._set_property(["license"], value)
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync metadata with pyproject.toml file."""
@@ -223,6 +224,8 @@ class Poetry(PyprojectCommon):
 
         # Restore original _from_person method
         self._from_person = original_from_person  # type: ignore
+
+        self.license = license_expression(metadata.license)
 
         # For Poetry v2, convert authors and maintainers from array of tables to inline tables
         if self._poetry_version == 2:
@@ -252,7 +255,6 @@ class SetupTools(PyprojectCommon):
             "homepage": ["urls", "homepage"],
             "repository": ["urls", "repository"],
             "documentation": ["urls", "documentation"],
-            "license": ["license", "text"],
         }
         super().__init__(
             path,
@@ -295,14 +297,7 @@ class SetupTools(PyprojectCommon):
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync metadata with pyproject.toml file and fix license field."""
         super().sync(metadata)
-
-        # if license field has both text and file, remove file
-        if (
-            self._get_property(["license", "file"]) is not None
-            and self._get_property(["license", "text"]) is not None
-        ):
-            # delete license file property
-            self._data["project"]["license"].pop("file")
+        self.license = license_expression(metadata.license)
 
 
 # ----

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -19,7 +19,10 @@ logger = logging.getLogger("somesy")
 
 def license_expression(licenses) -> str:
     """Convert one or more license identifiers to an SPDX expression."""
-    return " OR ".join(str(license) for license in (licenses if isinstance(licenses, list) else [licenses]))
+    return " OR ".join(
+        str(license)
+        for license in (licenses if isinstance(licenses, list) else [licenses])
+    )
 
 
 class PyprojectCommon(ProjectMetadataWriter):

--- a/src/somesy/rust/writer.py
+++ b/src/somesy/rust/writer.py
@@ -172,6 +172,9 @@ class Rust(ProjectMetadataWriter):
         """Sync the rust config with the project metadata."""
         super().sync(metadata)
 
+        if isinstance(metadata.license, list):
+            self.license = " OR ".join(license.value for license in metadata.license)
+
         # if there is a license file, remove the license field
-        if self._get_key("license_file"):
+        if self._get_property(self._get_key("license_file")):
             self.license = None

--- a/tests/commands/test_sync.py
+++ b/tests/commands/test_sync.py
@@ -2,9 +2,32 @@
 
 from pathlib import Path
 
-from somesy.commands.sync import sync
+from somesy.commands.sync import _sync_file, sync
 from somesy.core.models import SomesyInput, SomesyConfig, ProjectMetadata
 from somesy.core.models import Person, LicenseEnum
+
+
+def test_sync_file_does_not_rewrite_unchanged_data(tmp_path):
+    class NoopWriter:
+        def __init__(self, path, **kwargs):
+            self._data = {"formatted": True}
+
+        def sync(self, metadata):
+            pass
+
+        def save(self, path):
+            raise AssertionError("unchanged output should not be saved")
+
+    _sync_file(
+        ProjectMetadata(
+            name="project",
+            description="description",
+            license="MIT",
+            people=[Person(given_names="A", family_names="B", author=True)],
+        ),
+        tmp_path / "metadata",
+        NoopWriter,
+    )
 
 
 def test_basic_sync(create_files, file_types):

--- a/tests/input/test_core_core.py
+++ b/tests/input/test_core_core.py
@@ -101,6 +101,11 @@ def test_somesy_input(somesy_input):
     assert authors[1].publication_author is True
 
 
+def test_multiple_licenses(somesy_input):
+    somesy_input.project.license = [LicenseEnum.MIT, LicenseEnum.Apache_2_0]
+    assert somesy_input.project.license == [LicenseEnum.MIT, LicenseEnum.Apache_2_0]
+
+
 def test_multiple_inputs(create_files, file_types):
     """Test handling of multiple input files for the same format."""
     # Create test files in multiple locations

--- a/tests/output/test_cff_writer.py
+++ b/tests/output/test_cff_writer.py
@@ -23,6 +23,17 @@ def test_sync(cff: CFF, somesy_input: dict):
     assert cff.version == "1.0.0"
 
 
+def test_save_does_not_write_trailing_whitespace(tmp_path):
+    file_path = tmp_path / "CITATION.cff"
+    cff = CFF(file_path, create_if_not_exists=True)
+    cff.repository = "https://github.com/Materials-Data-Science-and-Informatics/somesy"
+    cff.save()
+
+    assert all(
+        not line.endswith((" ", "\t")) for line in file_path.read_text().splitlines()
+    )
+
+
 def test_save(tmp_path):
     # test save with default path
     file_path = tmp_path / "CITATION.cff"

--- a/tests/output/test_codemeta.py
+++ b/tests/output/test_codemeta.py
@@ -44,6 +44,23 @@ def test_update_codemeta(somesy_input, tmp_path):
     assert dat3 != dat4
 
 
+def test_multiple_licenses(somesy_input, tmp_path):
+    codemeta_file = tmp_path / "codemeta.json"
+    somesy_input.project.license = [
+        somesy_input.project.license,
+        "Apache-2.0",
+    ]
+    cm = CodeMeta(codemeta_file, merge=False)
+    cm.sync(somesy_input.project)
+    cm.save()
+
+    data = json.loads(codemeta_file.read_text())
+    assert data["license"] == [
+        "https://spdx.org/licenses/MIT",
+        "https://spdx.org/licenses/Apache-2.0",
+    ]
+
+
 def test_update_codemeta_with_merge(somesy_input, tmp_path):
     codemeta_file = tmp_path / "codemeta.json"
 

--- a/tests/output/test_fortran_writer.py
+++ b/tests/output/test_fortran_writer.py
@@ -31,6 +31,12 @@ def test_sync(fortran, somesy_input):
     assert fortran.authors[0] == "John Doe <john.doe@example.com>"
 
 
+def test_multiple_licenses(fortran, somesy_input):
+    somesy_input.project.license = [LicenseEnum.MIT, LicenseEnum.Apache_2_0]
+    fortran.sync(somesy_input.project)
+    assert fortran.license == "MIT OR Apache-2.0"
+
+
 def test_sync_free_text(fortran_file, somesy_input):
     # update author to have a free text format
     content = fortran_file.read_text()

--- a/tests/output/test_pom_writer.py
+++ b/tests/output/test_pom_writer.py
@@ -18,7 +18,7 @@ def pom_file(create_files, file_types):
 def test_content_match(pom: POM):
     assert pom.name == "test-package"
     assert pom.description == "This is a test package for demonstration purposes."
-    assert pom.license == "MIT"
+    assert pom.license == ["MIT", "Apache-2.0"]
     assert len(pom.authors) == 1
 
 
@@ -26,6 +26,12 @@ def test_sync(pom: POM, somesy_input: dict):
     pom.sync(somesy_input.project)
     assert pom.name == "testproject"
     assert pom.version == "1.0.0"
+
+
+def test_multiple_licenses(pom: POM, somesy_input):
+    somesy_input.project.license = [LicenseEnum.MIT, LicenseEnum.Apache_2_0]
+    pom.sync(somesy_input.project)
+    assert pom.license == ["MIT", "Apache-2.0"]
 
 
 def test_save(tmp_path):

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -76,6 +76,39 @@ def test_sync(pyproject_poetry, pyproject_poetry2, pyproject_setuptools, somesy_
     assert_sync(pyproject_setuptools)
 
 
+@pytest.mark.parametrize(
+    "writer_fixture, writer_class, version",
+    [
+        ("pyproject_poetry2_file", Poetry, 2),
+        ("pyproject_setuptools_file", SetupTools, None),
+    ],
+)
+def test_issue_121_writes_modern_license_string(
+    request, writer_fixture, writer_class, version, somesy_input
+):
+    path = request.getfixturevalue(writer_fixture)
+    writer = writer_class(path, version=version) if version else writer_class(path)
+    writer.sync(somesy_input.project)
+    assert writer._data["project"]["license"] == "MIT"
+
+
+@pytest.mark.parametrize(
+    "writer_fixture, writer_class, version",
+    [
+        ("pyproject_poetry2_file", Poetry, 2),
+        ("pyproject_setuptools_file", SetupTools, None),
+    ],
+)
+def test_issue_121_writes_multiple_license_expression(
+    request, writer_fixture, writer_class, version, somesy_input
+):
+    path = request.getfixturevalue(writer_fixture)
+    writer = writer_class(path, version=version) if version else writer_class(path)
+    somesy_input.project.license = [LicenseEnum.MIT, LicenseEnum.Apache_2_0]
+    writer.sync(somesy_input.project)
+    assert writer._data["project"]["license"] == "MIT OR Apache-2.0"
+
+
 def test_save(tmp_path, pyproject_poetry, pyproject_poetry2, pyproject_setuptools):
     def assert_save(pyproject):
         custom_path = tmp_path / Path("pyproject.toml")

--- a/tests/output/test_rust_writer.py
+++ b/tests/output/test_rust_writer.py
@@ -32,6 +32,12 @@ def test_sync(rust, somesy_input):
     assert rust.version == "1.0.0"
 
 
+def test_multiple_licenses(rust, somesy_input):
+    somesy_input.project.license = [LicenseEnum.MIT, LicenseEnum.Apache_2_0]
+    rust.sync(somesy_input.project)
+    assert rust.license == "MIT OR Apache-2.0"
+
+
 def test_save(tmp_path, rust):
     custom_path = tmp_path / Path("Cargo.toml")
     rust.save(custom_path)


### PR DESCRIPTION
## Summary

- Support multiple SPDX licenses in `somesy.toml`
- Preserve multiple licenses in POM and CodeMeta
- Emit SPDX `OR` expressions for Rust and Fortran
- Use the first license for single-value targets
- Replace deprecated pyproject license tables with SPDX strings
- Preserve legacy pyproject input compatibility

Closes #124
Fixes #121