### PR TITLE
Fix duplicate -P CLI warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 - modernize CI workflows and publish releases directly from CI
 - remove obsolete GitLab configuration and release workflows
 - support multiple SPDX licenses and modernize pyproject license output
+- fix duplicate `-P` CLI shortcut warning in `somesy sync`
 
 ## [v0.7.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.7.3) <small>(2025-03-14)</small> { id="0.7.3" }
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -199,6 +199,7 @@ somesy sync --help
 Everything that can be configured as a CLI flag can also be set in a `somesy.toml` file
 in the `[config]` section. CLI arguments set in an input file override the
 defaults, while options passed as CLI arguments override the configuration.
+The `-P` shortcut disables pyproject synchronization, while `-V` passes output validation.
 
 Without an input file specifically provided, somesy will check if it can find a valid
 

--- a/src/somesy/cli/sync.py
+++ b/src/somesy/cli/sync.py
@@ -155,7 +155,7 @@ def sync(
     pass_validation: bool | None = typer.Option(
         False,
         "--pass-validation",
-        "-P",
+        "-V",
         help="Pass validation of metadata files (default: False)",
     ),
     packages: list[Path] | None = typer.Option(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import pytest
 from typer.testing import CliRunner
@@ -18,10 +19,11 @@ def test_app_version():
 
 def test_sync_options_have_unique_shortcuts():
     result = runner.invoke(app, ["sync", "--help"])
+    output = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", result.stdout)
 
     assert result.exit_code == 0
-    assert "-P" in result.stdout and "--no-sync-pyproject" in result.stdout
-    assert "-V" in result.stdout and "--pass-validation" in result.stdout
+    assert "-P" in output and "--no-sync-pyproject" in output
+    assert "-V" in output and "--pass-validation" in output
     assert "parameter -P is used more than once" not in result.output
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,15 @@ def test_app_version():
     assert "somesy version: " in result.stdout
 
 
+def test_sync_options_have_unique_shortcuts():
+    result = runner.invoke(app, ["sync", "--help"])
+
+    assert result.exit_code == 0
+    assert "-P" in result.stdout and "--no-sync-pyproject" in result.stdout
+    assert "-V" in result.stdout and "--pass-validation" in result.stdout
+    assert "parameter -P is used more than once" not in result.output
+
+
 @pytest.mark.parametrize("log_level", [lv for lv in SomesyLogLevel])
 def test_log_levels(log_level):
     set_log_level(log_level)


### PR DESCRIPTION
Change the --pass-validation shortcut from -P to -V to remove Click’s duplicate-parameter warning. Updated CLI documentation, regression coverage, and the changelog.

Fixes #123