### PR TITLE
Fix POM synchronization for people without email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 - remove obsolete GitLab configuration and release workflows
 - support multiple SPDX licenses and modernize pyproject license output
 - fix duplicate `-P` CLI shortcut warning in `somesy sync`
+- fix POM synchronization for people without email addresses
 
 ## [v0.7.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.7.3) <small>(2025-03-14)</small> { id="0.7.3" }
 

--- a/src/somesy/pom_xml/writer.py
+++ b/src/somesy/pom_xml/writer.py
@@ -111,9 +111,9 @@ class POM(ProjectMetadataWriter):
             names = person_obj["name"].split()
             gnames = " ".join(names[:-1])
             fname = names[-1]
-            email = person_obj["email"]
+            email = person_obj.get("email")
             url = person_obj.get("url")
-            maybe_orcid = url if url.find("orcid.org") >= 0 else None
+            maybe_orcid = url if url and "orcid.org" in url else None
             if roles := person_obj.get("roles"):
                 contr = roles["role"]
             else:

--- a/tests/output/test_pom_writer.py
+++ b/tests/output/test_pom_writer.py
@@ -59,6 +59,30 @@ def test_from_to_person(person: Person):
     assert str(p.orcid) == str(person.orcid)
 
 
+def test_person_merge_without_email(tmp_path):
+    pom_path = tmp_path / "pom.xml"
+    person = Person(
+        given_names="Jane", family_names="Doe", author=True, maintainer=True
+    )
+    metadata = ProjectMetadata(
+        name="My awesome project",
+        description="Project description",
+        license=LicenseEnum.MIT,
+        version="0.1.0",
+        people=[person],
+    )
+
+    pom = POM(pom_path, create_if_not_exists=True)
+    pom.sync(metadata)
+    pom.save()
+
+    person.maintainer = False
+    pom = POM(pom_path)
+    pom.sync(metadata)
+
+    assert pom.authors[0]["name"] == person.full_name
+
+
 def test_person_merge(pom_file, person: Person):
     pj = POM(pom_file)
 


### PR DESCRIPTION
## Summary

- Handle missing email addresses when parsing POM developers.
- Handle missing URLs when checking for ORCID identifiers.
- Add regression coverage for repeated syncs with incomplete person metadata.
- Document the fix in the v0.8.0 changelog.

Fixes #122