### PR TITLE
Support PEP 621 dynamic fields in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 
 ## [v0.8.0](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.8.0) <small>(2026-09-03)</small> { id="0.8.0" }
 
+- support PEP 621 `dynamic` fields in `pyproject.toml` — fields listed in `dynamic` (e.g. `version`, `description`) are no longer required to be present and will not be overwritten during sync
 - raise the minimum supported Python version to 3.10
 - update project dependencies and pre-commit hooks
 - fix dependency vulnerabilities and replace Safety with pip-audit

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Here is an overview of all the currently supported files and formats.
 
 **Notes:**
 
-1. note that `somesy` does not support setuptools or poetry _dynamic fields_
+1. `somesy` supports PEP 621 `dynamic` fields — fields listed in `dynamic` (e.g. `version`) are not overwritten during sync
 2. `package.json` only supports one author, so `somesy` will pick the _first_ listed author
 3. `fpm.toml` only supports one author and maintainer, so `somesy` will pick the _first_ listed author and maintainer
 4. `pom.xml` has no concept of `maintainers`, but it can have multiple licenses

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -181,6 +181,29 @@ than just move or rename fields**. This means that giving a clean and complete
 mapping overview is not feasible. In case of doubt or confusion, please open an
 issue or consult the `somesy` code.
 
+### PEP 621 `dynamic` fields
+
+For `pyproject.toml` targets (setuptools and Poetry v2), somesy respects the
+[PEP 621 `dynamic` field](https://peps.python.org/pep-0621/#dynamic). If
+`version` or `description` is listed in `dynamic`, it means the value is
+provided at build time rather than written statically in the file. In this case
+somesy will:
+
+- **skip validation** of that field (it is not required to be present in the file), and
+- **not overwrite** the field during sync, logging a warning instead.
+
+For example, if your `pyproject.toml` contains:
+
+```toml
+[project]
+name = "my-package"
+dynamic = ["version", "description"]
+```
+
+somesy will sync all other managed fields as usual but leave `version` and
+`description` untouched, because they are expected to be set dynamically at
+build time.
+
 **people** and **entities** are mapped to authors/maintainers/contributors depending
 on the output format. Both fields are marked as necessary but what `somesy` need is an
 author either in **people** or **entities**.
@@ -289,7 +312,7 @@ pyproject_toml_file = 'package2/pyproject.toml'
 
 !!! warning
 
-    Each output file, such as package.json file, have its required fields and these fields are enforced by `somesy`. However, in case of mono-repos or multi-package repositories, some of the fields could be omitted, such as `version`. Therefore, we suggest users to set `pass_validation` to `true` if this is the case. `somesy` will fail otherwise.
+    Each output file, such as package.json file, have its required fields and these fields are enforced by `somesy`. However, in case of mono-repos or multi-package repositories, some of the fields could be omitted, such as `version`. For `pyproject.toml` files, the preferred solution is to list those fields under `dynamic` (e.g. `dynamic = ["version"]`) — somesy will then skip validation and sync for those fields. For other formats, or as a last resort, you can set `pass_validation` to `true` in the somesy config to bypass validation entirely. `somesy` will fail otherwise.
 
 The example above shows a project with a `package.json` file in the root folder and 2 packages in it. Three files are set here so all of them will be updated according to ground truth of `somesy project metadata`.
 

--- a/src/somesy/pyproject/models.py
+++ b/src/somesy/pyproject/models.py
@@ -77,13 +77,34 @@ class PoetryConfig(BaseModel):
         Field(pattern=r"^[A-Za-z0-9]+([_-][A-Za-z0-9]+)*$", description="Package name"),
     ]
     version: Annotated[
-        str,
+        str | None,
         Field(
+            default=None,
             pattern=r"^\d+(\.\d+)*((a|b|rc)\d+)?(post\d+)?(dev\d+)?$",
             description="Package version",
         ),
     ]
-    description: Annotated[str, Field(description="Package description")]
+    description: Annotated[
+        str | None, Field(default=None, description="Package description")
+    ]
+    dynamic: Annotated[
+        list[str] | None, Field(default=None, description="PEP 621 dynamic fields")
+    ]
+
+    @model_validator(mode="after")
+    def validate_required_unless_dynamic(self):
+        """Validate that version and description are present unless listed in dynamic."""
+        dynamic = self.dynamic or []
+        if self.version is None and "version" not in dynamic:
+            raise ValueError(
+                "Field 'version' is required when not listed in 'dynamic'."
+            )
+        if self.description is None and "description" not in dynamic:
+            raise ValueError(
+                "Field 'description' is required when not listed in 'dynamic'."
+            )
+        return self
+
     license: Annotated[
         LicenseEnum | list[LicenseEnum] | License | str | None,
         Field(description="An SPDX license identifier."),
@@ -203,9 +224,31 @@ class SetuptoolsConfig(BaseModel):
 
     name: Annotated[str, Field(pattern=r"^[A-Za-z0-9]+([_-][A-Za-z0-9]+)*$")]
     version: Annotated[
-        str, Field(pattern=r"^\d+(\.\d+)*((a|b|rc)\d+)?(post\d+)?(dev\d+)?$")
+        str | None,
+        Field(
+            default=None,
+            pattern=r"^\d+(\.\d+)*((a|b|rc)\d+)?(post\d+)?(dev\d+)?$",
+        ),
     ]
-    description: str
+    description: str | None = None
+    dynamic: Annotated[
+        list[str] | None, Field(default=None, description="PEP 621 dynamic fields")
+    ]
+
+    @model_validator(mode="after")
+    def validate_required_unless_dynamic(self):
+        """Validate that version and description are present unless listed in dynamic."""
+        dynamic = self.dynamic or []
+        if self.version is None and "version" not in dynamic:
+            raise ValueError(
+                "Field 'version' is required when not listed in 'dynamic'."
+            )
+        if self.description is None and "description" not in dynamic:
+            raise ValueError(
+                "Field 'description' is required when not listed in 'dynamic'."
+            )
+        return self
+
     readme: Path | list[Path] | File | None = None
     license: License | LicenseEnum | str | None = Field(
         None, description="An SPDX license identifier."

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -50,6 +50,43 @@ class PyprojectCommon(ProjectMetadataWriter):
             pass_validation=pass_validation,
         )
 
+    @property
+    def _dynamic_fields(self) -> list[str]:
+        """Return the list of fields marked as dynamic in pyproject.toml."""
+        return self._get_property(["dynamic"]) or []
+
+    @property
+    def version(self) -> str | None:
+        """Return the version of the project."""
+        return self._get_property(self._get_key("version"))
+
+    @version.setter
+    def version(self, value: str) -> None:
+        """Set version, skipping if listed as dynamic."""
+        if "version" in self._dynamic_fields:
+            if value:
+                logger.warning(
+                    "Field 'version' is listed as dynamic — skipping sync from somesy."
+                )
+            return
+        self._set_property(self._get_key("version"), value)
+
+    @property
+    def description(self) -> str | None:
+        """Return the description of the project."""
+        return self._get_property(self._get_key("description"))
+
+    @description.setter
+    def description(self, value: str) -> None:
+        """Set description, skipping if listed as dynamic."""
+        if "description" in self._dynamic_fields:
+            if value:
+                logger.warning(
+                    "Field 'description' is listed as dynamic — skipping sync from somesy."
+                )
+            return
+        self._set_property(self._get_key("description"), value)
+
     def _load(self) -> None:
         """Load pyproject.toml file."""
         with open(self.path) as f:

--- a/tests/input/test_pyproject_validate.py
+++ b/tests/input/test_pyproject_validate.py
@@ -53,3 +53,75 @@ def test_poetry_validate(tmp_path):
 
     # if we pass validation, it should not raise an error
     Pyproject(invalid_poetry_path, pass_validation=True)
+
+
+def test_dynamic_version_setuptools_valid(tmp_path):
+    """Setuptools: dynamic = ['version'] without version field should pass validation."""
+    obj = {
+        "project": {
+            "name": "somesy",
+            "description": "A test package",
+            "dynamic": ["version"],
+        }
+    }
+    path = tmp_path / "pyproject.toml"
+    with open(path, "w+") as f:
+        dump(obj, f)
+
+    p = Pyproject(path)
+    assert "version" in p._dynamic_fields
+
+
+def test_dynamic_version_poetry2_valid(tmp_path):
+    """Poetry v2: dynamic = ['version'] without version field should pass validation."""
+    obj = {
+        "tool": {"poetry": {}},
+        "project": {
+            "name": "somesy",
+            "description": "A test package",
+            "dynamic": ["version"],
+            "license": "MIT",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+        },
+    }
+    path = tmp_path / "pyproject.toml"
+    with open(path, "w+") as f:
+        dump(obj, f)
+
+    p = Pyproject(path)
+    assert "version" in p._dynamic_fields
+
+
+def test_missing_version_not_dynamic_setuptools_fails(tmp_path):
+    """Setuptools: missing version without dynamic should fail validation."""
+    obj = {
+        "project": {
+            "name": "somesy",
+            "description": "A test package",
+        }
+    }
+    path = tmp_path / "pyproject.toml"
+    with open(path, "w+") as f:
+        dump(obj, f)
+
+    with pytest.raises(ValueError, match="version"):
+        Pyproject(path)
+
+
+def test_missing_version_not_dynamic_poetry2_fails(tmp_path):
+    """Poetry v2: missing version without dynamic should fail validation."""
+    obj = {
+        "tool": {"poetry": {}},
+        "project": {
+            "name": "somesy",
+            "description": "A test package",
+            "license": "MIT",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+        },
+    }
+    path = tmp_path / "pyproject.toml"
+    with open(path, "w+") as f:
+        dump(obj, f)
+
+    with pytest.raises(ValueError, match="version"):
+        Pyproject(path)

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -317,3 +318,93 @@ def test_without_email(tmp_path, person):
 
         assert len(p.authors) == 1
         assert len(p.maintainers) == 1
+
+
+def test_dynamic_version_not_synced_setuptools(tmp_path, caplog):
+    """Setuptools: version listed as dynamic should not be written during sync."""
+    pyproject_str = """\
+[project]
+name = "test-pkg"
+description = "A test"
+dynamic = ["version"]
+authors = [{ name = "John Doe", email = "john@example.com" }]
+license = { text = "MIT" }
+
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+"""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(pyproject_str)
+
+    st = SetupTools(path)
+    assert "version" in st._dynamic_fields
+
+    pm = ProjectMetadata(
+        name="test-pkg",
+        description="A test",
+        license=LicenseEnum.MIT,
+        version="1.0.0",
+        people=[
+            Person(
+                given_names="John",
+                family_names="Doe",
+                email="john@example.com",
+                author=True,
+            )
+        ],
+    )
+    with caplog.at_level(logging.WARNING, logger="somesy"):
+        st.sync(pm)
+
+    assert (
+        "version" not in st._data["project"]
+        or st._data["project"].get("version") is None
+    )
+    assert "dynamic" in caplog.text
+
+
+def test_dynamic_version_not_synced_poetry2(tmp_path, caplog):
+    """Poetry v2: version listed as dynamic should not be written during sync."""
+    pyproject_str = """\
+[project]
+name = "test-pkg"
+description = "A test"
+dynamic = ["version"]
+authors = [{ name = "John Doe", email = "john@example.com" }]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+"""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(pyproject_str)
+
+    p = Poetry(path, version=2)
+    assert "version" in p._dynamic_fields
+
+    pm = ProjectMetadata(
+        name="test-pkg",
+        description="A test",
+        license=LicenseEnum.MIT,
+        version="1.0.0",
+        people=[
+            Person(
+                given_names="John",
+                family_names="Doe",
+                email="john@example.com",
+                author=True,
+            )
+        ],
+    )
+    with caplog.at_level(logging.WARNING, logger="somesy"):
+        p.sync(pm)
+
+    assert (
+        "version" not in p._data["project"] or p._data["project"].get("version") is None
+    )
+    assert "dynamic" in caplog.text

--- a/tests/processing/test_core_base_model.py
+++ b/tests/processing/test_core_base_model.py
@@ -4,7 +4,7 @@ from typing import Optional
 from somesy.core.models import SomesyBaseModel
 
 
-class TestModel(SomesyBaseModel):
+class SampleModel(SomesyBaseModel):
     """Test model with some basic fields."""
 
     name: str = Field(alias="full_name")
@@ -15,7 +15,7 @@ class TestModel(SomesyBaseModel):
 def test_key_order():
     """Test custom key order functionality."""
     # Create a fresh model instance for each test
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
 
     # Test default order - should contain both keys, order doesn't matter
     default_keys = list(model.model_dump().keys())
@@ -42,7 +42,7 @@ def test_key_order():
 
 def test_model_copy_preserves_order():
     """Test that model_copy preserves custom key order."""
-    model = TestModel(full_name="John Doe", age=30, email="j.doe@example.com")
+    model = SampleModel(full_name="John Doe", age=30, email="j.doe@example.com")
     model.set_key_order(["age", "name", "email"])  # Use field names, not aliases
 
     copied = model.model_copy()
@@ -53,14 +53,14 @@ def test_model_copy_preserves_order():
 def test_make_partial():
     """Test make_partial class method with aliases."""
     data = {"full_name": "John Doe", "age": 30}
-    model = TestModel.make_partial(data)
+    model = SampleModel.make_partial(data)
     assert model.name == "John Doe"
     assert model.age == 30
 
 
 def test_model_dump_json():
     """Test JSON serialization with custom order."""
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
     model.set_key_order(["age", "name"])  # Use field names, not aliases
 
     # Test without aliases
@@ -76,7 +76,7 @@ def test_model_dump_json():
 
 def test_patch_kwargs_defaults():
     """Test default kwargs patching."""
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
 
     # Test that defaults are set
     kwargs = {}
@@ -91,7 +91,7 @@ def test_patch_kwargs_defaults():
 
 def test_reorder_dict():
     """Test dictionary reordering."""
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
 
     # Test with partial key order using field names
     model.set_key_order(["age", "name"])
@@ -102,23 +102,23 @@ def test_reorder_dict():
 
 def test_aliases():
     """Test alias mapping functionality."""
-    aliases = TestModel._aliases()
+    aliases = SampleModel._aliases()
     assert aliases == {"full_name": "name", "age": "age", "email": "email"}
 
 
 def test_model_config():
     """Test model configuration."""
-    assert TestModel.model_config["extra"] == "forbid"
-    assert TestModel.model_config["validate_assignment"] is True
-    assert TestModel.model_config["populate_by_name"] is True
-    assert TestModel.model_config["str_strip_whitespace"] is True
-    assert TestModel.model_config["str_min_length"] == 1
+    assert SampleModel.model_config["extra"] == "forbid"
+    assert SampleModel.model_config["validate_assignment"] is True
+    assert SampleModel.model_config["populate_by_name"] is True
+    assert SampleModel.model_config["str_strip_whitespace"] is True
+    assert SampleModel.model_config["str_min_length"] == 1
 
 
 def test_key_order_empty():
     """Test behavior when key_order is empty."""
     # Create a fresh model instance
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
 
     # Explicitly ensure no key order is set
     model._key_order = None
@@ -134,7 +134,7 @@ def test_key_order_empty():
 
 def test_model_dump_with_none():
     """Test model dump with None values and exclude_none=False."""
-    model = TestModel(full_name="John Doe", age=30, email=None)
+    model = SampleModel(full_name="John Doe", age=30, email=None)
     dumped = model.model_dump(exclude_none=False)
     # exclude default takes precedence so email should not be there
     assert not "email" in dumped
@@ -142,7 +142,7 @@ def test_model_dump_with_none():
 
 def test_model_dump_json_with_none():
     """Test model dump_json with None values and exclude_none=False."""
-    model = TestModel(full_name="John Doe", age=30, email=None)
+    model = SampleModel(full_name="John Doe", age=30, email=None)
     json_str = model.model_dump_json(exclude_none=False)
     # exclude default takes precedence so email should not be there
     assert '"email"' not in json_str
@@ -150,7 +150,7 @@ def test_model_dump_json_with_none():
 
 def test_set_key_order_with_aliases():
     """Test setting key order with alias names."""
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
     # Set order using aliases
     model.set_key_order(["full_name", "age"])
     # Should convert aliases to field names internally
@@ -159,14 +159,14 @@ def test_set_key_order_with_aliases():
 
 def test_model_dump_json_ensure_ascii():
     """Test JSON serialization with non-ASCII characters."""
-    model = TestModel(full_name="José Doé", age=30)
+    model = SampleModel(full_name="José Doé", age=30)
     json_str = model.model_dump_json()
     assert "José" in json_str  # Should not be escaped because ensure_ascii=False
 
 
 def test_reorder_dict_missing_keys():
     """Test reordering with keys missing from the input dict."""
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
     model.set_key_order(["missing_key", "age", "name"])
     dct = {"name": "John Doe", "age": 30}
     reordered = model._reorder_dict(dct)
@@ -175,7 +175,7 @@ def test_reorder_dict_missing_keys():
 
 def test_model_dump_with_by_alias_and_exclude():
     """Test model dump with both by_alias and exclude options."""
-    model = TestModel(full_name="John Doe", age=30, email=None)
+    model = SampleModel(full_name="John Doe", age=30, email=None)
     dumped = model.model_dump(by_alias=True, exclude={"email"})
     assert "full_name" in dumped
     assert "email" not in dumped
@@ -183,7 +183,7 @@ def test_model_dump_with_by_alias_and_exclude():
 
 def test_model_dump_json_with_by_alias_and_exclude():
     """Test model dump_json with both by_alias and exclude options."""
-    model = TestModel(full_name="John Doe", age=30, email=None)
+    model = SampleModel(full_name="John Doe", age=30, email=None)
     json_str = model.model_dump_json(by_alias=True, exclude={"email"})
     assert "full_name" in json_str
     assert "email" not in json_str
@@ -195,7 +195,7 @@ def test_patch_kwargs_defaults_no_change():
         "exclude_defaults": True,
         "exclude_none": True,
     }
-    model = TestModel(full_name="John Doe", age=30)
+    model = SampleModel(full_name="John Doe", age=30)
     original_kwargs = kwargs.copy()
     model._patch_kwargs_defaults(kwargs)
     assert kwargs == original_kwargs
@@ -204,6 +204,6 @@ def test_patch_kwargs_defaults_no_change():
 def test_make_partial_with_unknown_field():
     """Test make_partial with an unknown field."""
     data = {"full_name": "John Doe", "age": 30, "unknown": "value"}
-    model = TestModel.make_partial(data)
+    model = SampleModel.make_partial(data)
     assert model.name == "John Doe"
     assert model.age == 30


### PR DESCRIPTION
`version`, `description` fields listed in `dynamic`  are now skipped during validation and sync — somesy will not overwrite values that are managed dynamically at build time (e.g. by setuptools-scm).

Closes #119