### PR TITLE
Add somesy init and metadata harvesting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Check that all static analysis tools run without errors
         run: |
+          poetry config virtualenvs.in-project true
           poetry install  # so somesy can check itself
           poetry run poe lint --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
       rev: 'v2.3.1'
       hooks:
           - id: mypy
+    - repo: https://github.com/RobertCraigie/pyright-python
+      rev: v1.1.411
+      hooks:
+          - id: pyright
+            pass_filenames: false
 
     # Metadata
     - repo: https://github.com/citation-file-format/cff-converter-python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           - id: check-github-workflows
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.16.5
+      rev: v0.16.6
       hooks:
           # Run the linter.
           - id: ruff-check
@@ -36,9 +36,6 @@ repos:
       rev: 'v2.3.1'
       hooks:
           - id: mypy
-            args: [--no-strict-optional, --ignore-missing-imports]
-            # NOTE: you might need to add some deps here:
-            additional_dependencies: []
 
     # Metadata
     - repo: https://github.com/citation-file-format/cff-converter-python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 - fix duplicate `-P` CLI shortcut warning in `somesy sync`
 - fix POM synchronization for people without email addresses
 - add `somesy init` to harvest metadata and create a project `somesy.toml`
+- add pyright hook
 
 ## [v0.7.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.7.3) <small>(2025-03-14)</small> { id="0.7.3" }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 - support multiple SPDX licenses and modernize pyproject license output
 - fix duplicate `-P` CLI shortcut warning in `somesy sync`
 - fix POM synchronization for people without email addresses
+- add `somesy init` to harvest metadata and create a project `somesy.toml`
 
 ## [v0.7.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.7.3) <small>(2025-03-14)</small> { id="0.7.3" }
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,27 @@ As Helmholtz Metadata Collaboration (HMC), our goal is to increase usage of meta
 Alternatively, you can also add the somesy configuration to an existing
 `pyproject.toml`, `package.json`, `Project.toml`, or `fpm.toml` file. The somesy [manual](https://materials-data-science-and-informatics.github.io/somesy/main/manual/#somesy-input-file) contains examples showing how to do that.
 
+### Initialize a project
+
+For an existing project, `somesy init` harvests metadata from supported project
+files and Git history, merges it, and creates `somesy.toml`:
+
+```bash
+somesy init
+```
+
+The command asks only for required metadata that could not be harvested: project
+name, description, SPDX license, and one author. An author can be a person or an
+organization. Existing project files are enabled as sync targets; absent files
+are disabled. Use `--output-file` to choose another path or `--overwrite` to
+replace an existing file.
+
+```bash
+somesy init --output-file somesy.toml --overwrite
+```
+
+For manual configuration of sync options, use `somesy init config`.
+
 ### Using somesy
 
 Once somesy is installed and configured, somesy can take over and manage your project metadata.
@@ -146,13 +167,13 @@ formats further below.
 By default, `somesy` will create (if they did not exist) or update `CITATION.cff` and `codemeta.json` files in your repository.
 If you happen to use
 
--   `pyproject.toml` (in Python projects),
--   `package.json` (in JavaScript projects),
--   `Project.toml` (in Julia projects),
--   `fpm.toml` (in Fortran projects),
--   `pom.xml` (in Java projects),
--   `mkdocs.yml` (in projects using MkDocs),
--   `Cargo.toml` (in Rust projects)
+- `pyproject.toml` (in Python projects),
+- `package.json` (in JavaScript projects),
+- `Project.toml` (in Julia projects),
+- `fpm.toml` (in Fortran projects),
+- `pom.xml` (in Java projects),
+- `mkdocs.yml` (in projects using MkDocs),
+- `Cargo.toml` (in Rust projects)
 
 then somesy would also update the respective information there.
 
@@ -176,7 +197,7 @@ file in the root folder of your repository:
 repos:
     # ... (your other hooks) ...
     - repo: https://github.com/Materials-Data-Science-and-Informatics/somesy
-      rev: 'v0.7.2'
+      rev: 'v0.8.0'
       hooks:
           - id: somesy
 ```
@@ -188,8 +209,8 @@ repos:
 Note that `pre-commit` gives `somesy` the [staged](https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F) version of files,
 so when using `somesy` with pre-commit, keep in mind that
 
--   if `somesy` changed some files, you need to `git add` them again (and rerun pre-commit)
--   if you explicitly run `pre-commit`, make sure to `git add` all changed files (just like before a commit)
+- if `somesy` changed some files, you need to `git add` them again (and rerun pre-commit)
+- if you explicitly run `pre-commit`, make sure to `git add` all changed files (just like before a commit)
 
 <!-- --8<-- [end:precommit] -->
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -224,6 +224,43 @@ in the `[config]` section. CLI arguments set in an input file override the
 defaults, while options passed as CLI arguments override the configuration.
 The `-P` shortcut disables pyproject synchronization, while `-V` passes output validation.
 
+### Initialize a project
+
+Use `somesy init` to create a standalone `somesy.toml` from an existing project:
+
+```bash
+somesy init
+```
+
+Initialization reads metadata from all supported project files present in the
+current directory and harvests project information and authors from Git history.
+The harvested values are merged into Somesy’s general metadata model before the
+file is written.
+
+Only missing required values are requested interactively:
+
+- project name
+- project description
+- SPDX license
+- one author, as either a person or an entity
+
+For a person, the command asks for given names, family names, and optionally an
+email address. For an entity, it asks for the organization name and optionally
+an email address. Git authors count as project authors; therefore, the author
+prompt is shown only when no author was found in the harvested metadata.
+
+Detected project files are enabled as synchronization targets. Targets that are
+not present are disabled in the generated `[config]` section. The generated file
+is not overwritten by default:
+
+```bash
+somesy init --output-file path/to/somesy.toml
+somesy init --overwrite
+```
+
+Use `somesy init config` when you want to configure synchronization options
+manually instead of deriving them from the files in the project.
+
 Without an input file specifically provided, somesy will check if it can find a valid
 
 -   `.somesy.toml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,19 @@ extend-select = ["I", "D", "B", "S", "W"]
 ignore = ["D203", "D213", "D407", "B008"]
 
 [tool.ruff.lint.per-file-ignores]
-"**/{tests,docs}/*" = ["ALL"]
+"**/docs/*" = ["ALL"]
+"**/tests/*" = [
+    "C408",
+    "C417",
+    "D",
+    "DTZ007",
+    "S101",
+    "S603",
+    "S607",
+    "S108",
+    "SIM115",
+    "TRY004",
+]
 
 [tool.licensecheck]
 using = "poetry"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,9 @@ using = "poetry"
 
 [tool.mypy]
 disable_error_code = ["attr-defined"]
+
+[tool.pyright]
+include = ["src"]
+venvPath = "."
+venv = ".venv"
+typeCheckingMode = "standard"

--- a/src/somesy/cli/init.py
+++ b/src/somesy/cli/init.py
@@ -2,17 +2,133 @@
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import typer
 
-from somesy.commands import init_config
+from somesy.commands import init_config, write_somesy_file
 from somesy.core.core import discover_input
 from somesy.core.log import SomesyLogLevel, set_log_level
+from somesy.core.models import Person, SomesyConfig
+from somesy.core.types import LicenseEnum
+from somesy.git.harvest import harvest as harvest_git
+from somesy.harvest import harvest_sources
+from somesy.merge import merge_metadata
 
-from .util import wrap_exceptions
+from .util import file_arg_config, wrap_exceptions
 
 logger = logging.getLogger("somesy")
 app = typer.Typer()
+
+
+def _prompt_missing_metadata(
+    sources: list[tuple[Path, dict[str, Any]]], git_metadata
+) -> dict[str, Any]:
+    """Prompt for required metadata that harvesting did not provide."""
+    harvested = [content for _, content in sources]
+    if git_metadata is not None:
+        harvested.append(git_metadata.model_dump(exclude_none=True))
+    fallback: dict[str, Any] = {}
+
+    for field, prompt in {
+        "name": "Project name",
+        "description": "Project description",
+    }.items():
+        if not any(source.get(field) for source in harvested):
+            fallback[field] = typer.prompt(prompt)
+
+    if not any(source.get("license") for source in harvested):
+        while True:
+            value = typer.prompt("SPDX license")
+            try:
+                fallback["license"] = LicenseEnum(value)
+                break
+            except ValueError:
+                typer.echo(f"Unknown SPDX license: {value}")
+
+    def is_author(person: Any) -> bool:
+        return (
+            person.get("author", False)
+            if isinstance(person, dict)
+            else getattr(person, "author", False)
+        )
+
+    has_author = any(
+        any(is_author(person) for person in source.get(key, []) or [])
+        for source in harvested
+        for key in ("people", "entities", "authors")
+    )
+    if not has_author:
+        author_type = typer.prompt("Author type", type=str, default="person").lower()
+        while author_type not in {"person", "entity"}:
+            typer.echo("Author type must be 'person' or 'entity'.")
+            author_type = typer.prompt("Author type", default="person").lower()
+        if author_type == "person":
+            person = {
+                "given_names": typer.prompt("Author given names"),
+                "family_names": typer.prompt("Author family names"),
+                "author": True,
+            }
+            email = typer.prompt("Author email", default="")
+            if email:
+                person["email"] = email
+            fallback["people"] = [Person(**person)]
+        else:
+            name = typer.prompt("Author organization")
+            fallback["entities"] = [{"name": name, "author": True}]
+            email = typer.prompt("Author email", default="")
+            if email:
+                fallback["entities"][0]["email"] = email
+
+    return fallback
+
+
+@app.callback(invoke_without_command=True)
+@wrap_exceptions
+def initialize(
+    ctx: typer.Context,
+    output_file: Path = typer.Option(
+        Path("somesy.toml"),
+        "--output-file",
+        "-o",
+        help="Path for the generated somesy.toml file (default: somesy.toml).",
+        **file_arg_config,
+    ),
+    overwrite: bool = typer.Option(False, "--overwrite"),
+):
+    """Harvest project metadata and create a somesy.toml file."""
+    if ctx.invoked_subcommand is not None:
+        return
+    root = Path.cwd()
+    sources = harvest_sources(root)
+    git_metadata = harvest_git(root)
+    fallback = _prompt_missing_metadata(sources, git_metadata)
+    source_content = [content for _, content in sources]
+    if fallback:
+        source_content.append(fallback)
+    metadata = merge_metadata(source_content, git_metadata)
+    source_names = {path.name for path, _ in sources}
+    config = None
+    if source_names:
+        config = SomesyConfig(
+            **{
+                f"no_sync_{key}": filename not in source_names
+                for key, filename in {
+                    "pyproject": "pyproject.toml",
+                    "package_json": "package.json",
+                    "julia": "Project.toml",
+                    "fortran": "fpm.toml",
+                    "pom_xml": "pom.xml",
+                    "mkdocs": "mkdocs.yml",
+                    "rust": "Cargo.toml",
+                    "cff": "CITATION.cff",
+                    "codemeta": "codemeta.json",
+                }.items()
+            }
+        )
+    output = output_file if output_file.is_absolute() else root / output_file
+    write_somesy_file(metadata, output, config=config, overwrite=overwrite)
+    typer.echo(f"Created {output}")
 
 
 @app.command()
@@ -23,8 +139,8 @@ def config():
     input_file_default = discover_input()
 
     # prompt for inputs
-    input_file = typer.prompt("Input file path", default=input_file_default)
-    options = {"input_file": Path(input_file)}
+    input_file = Path(typer.prompt("Input file path", default=input_file_default))
+    options: dict[str, Any] = {"input_file": Path(input_file)}
 
     # ----
 

--- a/src/somesy/cli/init.py
+++ b/src/somesy/cli/init.py
@@ -110,8 +110,8 @@ def initialize(
     source_names = {path.name for path, _ in sources}
     config = None
     if source_names:
-        config = SomesyConfig(
-            **{
+        config = SomesyConfig.model_validate(
+            {
                 f"no_sync_{key}": filename not in source_names
                 for key, filename in {
                     "pyproject": "pyproject.toml",

--- a/src/somesy/cli/util.py
+++ b/src/somesy/cli/util.py
@@ -2,6 +2,7 @@
 
 import logging
 import traceback
+from typing import TypedDict
 
 import typer
 import wrapt
@@ -15,16 +16,38 @@ from somesy.core.models import SomesyConfig, SomesyInput
 logger = logging.getLogger("somesy")
 
 
+class FileArgConfig(TypedDict):
+    """Keyword arguments shared by Typer file options."""
+
+    file_okay: bool
+    dir_okay: bool
+    writable: bool
+    readable: bool
+    resolve_path: bool
+
+
+class ExistingFileArgConfig(FileArgConfig):
+    """File option arguments that require an existing file."""
+
+    exists: bool
+
+
 # configuration dicts for CLI file arguments
-file_arg_config = {
+file_arg_config: FileArgConfig = {
     "file_okay": True,
     "dir_okay": False,
     "writable": True,
     "readable": True,
     "resolve_path": True,
 }
-existing_file_arg_config = dict(file_arg_config)
-existing_file_arg_config.update({"exists": True})
+existing_file_arg_config: ExistingFileArgConfig = {
+    "file_okay": True,
+    "dir_okay": False,
+    "writable": True,
+    "readable": True,
+    "resolve_path": True,
+    "exists": True,
+}
 
 
 @wrapt.decorator

--- a/src/somesy/codemeta/utils.py
+++ b/src/somesy/codemeta/utils.py
@@ -54,9 +54,11 @@ def validate_codemeta(codemeta: dict) -> list:
         # Expand and compact to validate terms
         expanded = jsonld.expand(codemeta_copy)
         compacted = jsonld.compact(expanded, schema_context)
+        if not isinstance(compacted, dict):
+            raise TypeError("Codemeta compaction did not produce an object")
 
         # Check for unmapped fields (fields with ':' indicating schema prefix)
-        compacted_keys = compacted.keys()
+        compacted_keys = set(compacted)
         for key in compacted_keys:
             if ":" in key:
                 logger.error(f"Invalid schema reference found: {key}")
@@ -64,7 +66,7 @@ def validate_codemeta(codemeta: dict) -> list:
 
         # Check for unsupported terms by comparing original and compacted keys
         original_keys = set(codemeta.keys())
-        compacted_keys = set(compacted.keys())
+        compacted_keys = set(compacted)
 
         # Remove @type from comparison as it might be handled differently in compaction
         original_keys.discard("@type")

--- a/src/somesy/codemeta/writer.py
+++ b/src/somesy/codemeta/writer.py
@@ -3,10 +3,12 @@
 import json
 import logging
 from collections import OrderedDict
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 from somesy.codemeta.utils import validate_codemeta
+from somesy.core.log import VERBOSE
 from somesy.core.models import Entity, Person, ProjectMetadata
 from somesy.core.writer import FieldKeyMapping, ProjectMetadataWriter
 
@@ -45,7 +47,7 @@ class CodeMeta(ProjectMetadataWriter):
         }
         # delete the file if it exists
         if path.is_file() and not self.merge:
-            logger.verbose("Deleting existing codemeta.json file.")
+            logger.log(VERBOSE, "Deleting existing codemeta.json file.")
             path.unlink()
         super().__init__(
             path,
@@ -201,28 +203,28 @@ class CodeMeta(ProjectMetadataWriter):
             return entity_dict
 
     @staticmethod
-    def _to_person(person) -> Person | Entity:
+    def _to_person(person_obj) -> Person | Entity:
         """Convert codemeta.json dict or str for person/entity format to project metadata person object."""
-        if "name" in person:
-            entity_obj = {"name": person["name"]}
+        if "name" in person_obj:
+            entity_obj = {"name": person_obj["name"]}
             return Entity(**entity_obj)
         else:
-            person_obj = {}
-            if "givenName" in person:
-                person_obj["given_names"] = person["givenName"].strip()
-            if "familyName" in person:
-                person_obj["family_names"] = person["familyName"].strip()
-            if "email" in person:
-                person_obj["email"] = person["email"].strip()
-            if "@id" in person:
-                person_obj["orcid"] = person["@id"].strip()
-            if "address" in person:
-                person_obj["address"] = person["address"].strip()
+            person_data = {}
+            if "givenName" in person_obj:
+                person_data["given_names"] = person_obj["givenName"].strip()
+            if "familyName" in person_obj:
+                person_data["family_names"] = person_obj["familyName"].strip()
+            if "email" in person_obj:
+                person_data["email"] = person_obj["email"].strip()
+            if "@id" in person_obj:
+                person_data["orcid"] = person_obj["@id"].strip()
+            if "address" in person_obj:
+                person_data["address"] = person_obj["address"].strip()
 
-            return Person(**person_obj)
+            return Person(**person_data)
 
     def _sync_person_list(
-        self, old: list[Any], new: list[Person | Entity]
+        self, old: list[Any], new: Sequence[Person | Entity]
     ) -> list[Any]:
         """Override the _sync_person_list function from ProjectMetadataWriter.
 
@@ -236,7 +238,7 @@ class CodeMeta(ProjectMetadataWriter):
             List[Any]: list of new persons to add to codemeta.json file
 
         """
-        return new
+        return list(new)
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync codemeta.json with project metadata.

--- a/src/somesy/commands/__init__.py
+++ b/src/somesy/commands/__init__.py
@@ -1,6 +1,6 @@
 """Commands for somesy."""
 
-from .init_config import init_config
+from .init_config import init_config, write_somesy_file
 from .sync import sync
 
-__all__ = ["init_config", "sync"]
+__all__ = ["init_config", "sync", "write_somesy_file"]

--- a/src/somesy/commands/init_config.py
+++ b/src/somesy/commands/init_config.py
@@ -7,6 +7,7 @@ import tomlkit
 from pydantic import BaseModel
 
 from somesy.core.core import get_input_content
+from somesy.core.log import VERBOSE
 from somesy.core.models import ProjectMetadata, SomesyConfig, SomesyInput
 
 logger = logging.getLogger("somesy")
@@ -49,7 +50,7 @@ def init_config(input_path: Path, options: dict) -> None:
     is_somesy = SomesyInput.is_somesy_file_path(input_path)
     input_file_type = "somesy" if is_somesy else "pyproject"
     msg = f"Found input file with {input_file_type} format."
-    logger.verbose(msg)
+    logger.log(VERBOSE, msg)
 
     logger.debug(f"Input file content: {options}")
 

--- a/src/somesy/commands/init_config.py
+++ b/src/somesy/commands/init_config.py
@@ -4,9 +4,10 @@ import logging
 from pathlib import Path
 
 import tomlkit
+from pydantic import BaseModel
 
 from somesy.core.core import get_input_content
-from somesy.core.models import ProjectMetadata, SomesyInput
+from somesy.core.models import ProjectMetadata, SomesyConfig, SomesyInput
 
 logger = logging.getLogger("somesy")
 
@@ -15,13 +16,20 @@ def write_somesy_file(
     metadata: ProjectMetadata,
     path: Path = Path("somesy.toml"),
     *,
+    config: SomesyConfig | None = None,
     overwrite: bool = False,
 ) -> None:
     """Write project metadata to a standalone ``somesy.toml`` file."""
     if path.exists() and not overwrite:
         raise FileExistsError(f"Output file already exists: {path}")
 
-    content = {"project": metadata.model_dump(mode="json", by_alias=True)}
+    content = {
+        "project": BaseModel.model_dump(
+            metadata, mode="json", by_alias=True, exclude_none=True
+        )
+    }
+    if config is not None:
+        content["config"] = config.model_dump(mode="json", by_alias=True)
     with open(path, "w" if overwrite else "x") as file:
         tomlkit.dump(content, file)
 

--- a/src/somesy/commands/init_config.py
+++ b/src/somesy/commands/init_config.py
@@ -6,9 +6,24 @@ from pathlib import Path
 import tomlkit
 
 from somesy.core.core import get_input_content
-from somesy.core.models import SomesyInput
+from somesy.core.models import ProjectMetadata, SomesyInput
 
 logger = logging.getLogger("somesy")
+
+
+def write_somesy_file(
+    metadata: ProjectMetadata,
+    path: Path = Path("somesy.toml"),
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Write project metadata to a standalone ``somesy.toml`` file."""
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"Output file already exists: {path}")
+
+    content = {"project": metadata.model_dump(mode="json", by_alias=True)}
+    with open(path, "w" if overwrite else "x") as file:
+        tomlkit.dump(content, file)
 
 
 def init_config(input_path: Path, options: dict) -> None:

--- a/src/somesy/commands/sync.py
+++ b/src/somesy/commands/sync.py
@@ -76,13 +76,13 @@ def sync(somesy_input: SomesyInput, is_package: bool = False):
     conf, metadata = somesy_input.config, somesy_input.project
 
     # Get the base directory from the input file's location
-    try:
-        base_dir = somesy_input._origin.parent
-    except AttributeError:
+    if somesy_input._origin is None:
         logger.warning(
             "No origin found for somesy input, using current working directory."
         )
         base_dir = Path.cwd()
+    else:
+        base_dir = somesy_input._origin.parent
 
     # Resolve all paths in the config relative to the base directory
     conf.resolve_paths(base_dir)

--- a/src/somesy/commands/sync.py
+++ b/src/somesy/commands/sync.py
@@ -9,6 +9,7 @@ from rich.pretty import pretty_repr
 from somesy.cff.writer import CFF
 from somesy.codemeta import CodeMeta
 from somesy.core.core import INPUT_FILES_ORDERED
+from somesy.core.log import VERBOSE
 from somesy.core.models import ProjectMetadata, SomesyConfig, SomesyInput
 from somesy.core.writer import ProjectMetadataWriter
 from somesy.fortran.writer import Fortran
@@ -30,19 +31,19 @@ def _sync_file(
     pass_validation: bool | None = False,
 ):
     """Sync metadata to a file using the provided writer."""
-    logger.verbose(f"Loading '{file.name}' ...")
+    logger.log(VERBOSE, f"Loading '{file.name}' ...")
     if writer_cls == CodeMeta:
         writer: ProjectMetadataWriter = writer_cls(
             file, merge=merge_codemeta, pass_validation=pass_validation
         )
     else:
         writer = writer_cls(file, pass_validation=pass_validation)
-    logger.verbose(f"Syncing '{file.name}' ...")
+    logger.log(VERBOSE, f"Syncing '{file.name}' ...")
     original_data = deepcopy(writer._data)
     writer.sync(metadata)
     if writer._data != original_data:
         writer.save(file)
-        logger.verbose(f"Saved synced '{file.name}'.\n")
+        logger.log(VERBOSE, f"Saved synced '{file.name}'.\n")
 
 
 def _sync_files(
@@ -107,6 +108,7 @@ def sync(somesy_input: SomesyInput, is_package: bool = False):
             # Try all possible input files in order of priority
             config_files = [package / file for file in INPUT_FILES_ORDERED]
             package_input = None
+            config_file: Path | None = None
 
             for config_file in config_files:
                 try:
@@ -121,6 +123,9 @@ def sync(somesy_input: SomesyInput, is_package: bool = False):
                     f"No valid somesy config found in package {package} "
                     f"(tried: {', '.join(str(f) for f in config_files)})"
                 )
+                continue
+
+            if config_file is None:
                 continue
 
             # Create new config with CLI options and package's input file

--- a/src/somesy/core/core.py
+++ b/src/somesy/core/core.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import tomlkit
 
+from .log import VERBOSE
+
 logger = logging.getLogger("somesy")
 
 INPUT_FILES_ORDERED = [
@@ -40,7 +42,7 @@ def discover_input(input_file: Path | None = None) -> Path:
             return input_file
         else:
             msg = f"Passed file '{input_file}' does not exist. Searching for usable somesy input file..."
-            logger.verbose(msg)
+            logger.log(VERBOSE, msg)
 
     for filename in INPUT_FILES_ORDERED:
         input_file = Path(filename)
@@ -51,7 +53,7 @@ def discover_input(input_file: Path | None = None) -> Path:
                 continue
 
             msg = f"Using '{input_file}' as somesy input file."
-            logger.verbose(msg)
+            logger.log(VERBOSE, msg)
             return input_file
 
     raise FileNotFoundError("No somesy input file found.")

--- a/src/somesy/core/log.py
+++ b/src/somesy/core/log.py
@@ -46,6 +46,7 @@ class SomesyLogLevel(Enum):
             return VERBOSE
         if lv == SomesyLogLevel.DEBUG:
             return logging.DEBUG
+        raise ValueError(f"Unsupported log level: {lv}")
 
 
 _log_level: SomesyLogLevel | None = None

--- a/src/somesy/core/models.py
+++ b/src/somesy/core/models.py
@@ -417,11 +417,12 @@ class ContributorBaseModel(SomesyBaseModel):
             return self.full_name
 
     @classmethod
-    def from_name_email_string(cls, person: str):
+    def from_name_email_string(cls, person: str) -> ContributorBaseModel:
         """Return the type of class based on an name/e-mail string like `full name <x@y.z>`.
 
         If the name is `A B C`, then `A B` will be the given names and `C` will be the family name.
         """
+        raise NotImplementedError
 
 
 class Entity(ContributorBaseModel):
@@ -471,11 +472,11 @@ class Entity(ContributorBaseModel):
         return self.name
 
     @classmethod
-    def from_name_email_string(cls, entity: str) -> Entity:
+    def from_name_email_string(cls, person: str) -> Entity:
         """Return an `Entity` based on an name/e-mail string like `name <x@y.z>`."""
-        m = re.match(r"\s*([^<]+)<([^>]+)>", entity)
+        m = re.match(r"\s*([^<]+)<([^>]+)>", person)
         if m is None:
-            return Entity(name=entity)
+            return Entity(name=person)
 
         name, mail = (
             m.group(1).strip(),
@@ -483,7 +484,7 @@ class Entity(ContributorBaseModel):
         )
         return Entity(name=name, email=mail)
 
-    def same_person(self, other: Entity) -> bool:
+    def same_person(self, other: Person | Entity) -> bool:
         """Return whether two Entity metadata records are about the same real person.
 
         Uses heuristic match based on email and name (whichever are provided).
@@ -567,7 +568,7 @@ class Person(ContributorBaseModel):
 
     @field_validator("orcid", mode="before")
     @classmethod
-    def orcid_from_string(cls, orcid: str) -> HttpUrlStr | None:
+    def orcid_from_string(cls, orcid: Any) -> Any:
         """Convert orcid id string to HttpUrlStr."""
         # orcid regex without https://orcid.org/ prefix
         orcid_regex = r"^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"
@@ -607,16 +608,8 @@ class Person(ContributorBaseModel):
         m = re.match(r"\s*([^<]+)<([^>]+)>", person)
         if m is None:
             names = [s.strip() for s in person.split()]
-            return Person(
-                **{
-                    "given-names": " ".join(names[:-1]),
-                    "family-names": names[-1],
-                }
-            )
-        if m is None:
-            names = [s.strip() for s in person.split()]
-            return Person(
-                **{
+            return Person.model_validate(
+                {
                     "given-names": " ".join(names[:-1]),
                     "family-names": names[-1],
                 }
@@ -627,8 +620,8 @@ class Person(ContributorBaseModel):
         )
         # NOTE: for our purposes, does not matter what are given or family names,
         # we only compare on full_name anyway.
-        return Person(
-            **{
+        return Person.model_validate(
+            {
                 "given-names": " ".join(names[:-1]),
                 "family-names": names[-1],
                 "email": mail,
@@ -751,13 +744,13 @@ class ProjectMetadata(SomesyBaseModel):
         description="Project authors, maintainers and contributors as entities (organizations).",
     )
 
-    def authors(self):
+    def authors(self) -> list[Person | Entity]:
         """Return people and entities explicitly marked as authors."""
-        authors = [p for p in self.people if p.author]
+        authors: list[Person | Entity] = [p for p in self.people if p.author]
         authors.extend([e for e in self.entities if e.author])
         return authors
 
-    def publication_authors(self):
+    def publication_authors(self) -> list[Person | Entity]:
         """Return people marked as publication authors.
 
         This always includes people marked as authors.
@@ -767,19 +760,21 @@ class ProjectMetadata(SomesyBaseModel):
             p.publication_author for p in self.entities
         ):
             return []
-        publication_authors = [p for p in self.people if p.publication_author]
+        publication_authors: list[Person | Entity] = [
+            p for p in self.people if p.publication_author
+        ]
         publication_authors.extend([e for e in self.entities if e.publication_author])
         return publication_authors
 
-    def maintainers(self):
+    def maintainers(self) -> list[Person | Entity]:
         """Return people and entities marked as maintainers."""
-        maintainers = [p for p in self.people if p.maintainer]
+        maintainers: list[Person | Entity] = [p for p in self.people if p.maintainer]
         maintainers.extend([e for e in self.entities if e.maintainer])
         return maintainers
 
-    def contributors(self):
+    def contributors(self) -> list[Person | Entity]:
         """Return only people and entities not marked as authors."""
-        contributors = [p for p in self.people if not p.author]
+        contributors: list[Person | Entity] = [p for p in self.people if not p.author]
         contributors.extend([e for e in self.entities if not e.author])
         return contributors
 

--- a/src/somesy/core/models.py
+++ b/src/somesy/core/models.py
@@ -271,7 +271,9 @@ class SomesyConfig(SomesyBaseModel):
     def get_input(self) -> SomesyInput:
         """Based on the somesy config, load the complete somesy input."""
         # get metadata+config from specified input file
-        somesy_input = SomesyInput.from_input_file(self.input_file)
+        somesy_input = SomesyInput.from_input_file(
+            self.input_file or Path("somesy.toml")
+        )
         # update input with merged config settings (cli overrides config file)
         dct: dict[str, Any] = {}
         dct.update(somesy_input.config or {})
@@ -299,16 +301,21 @@ class SomesyConfig(SomesyBaseModel):
         # Resolve all file paths
         resolved_input = resolve_path(self.input_file)
         self.input_file = resolved_input if isinstance(resolved_input, Path) else None
-        self.pyproject_file = resolve_path(self.pyproject_file)
-        self.package_json_file = resolve_path(self.package_json_file)
-        self.julia_file = resolve_path(self.julia_file)
-        self.fortran_file = resolve_path(self.fortran_file)
-        self.pom_xml_file = resolve_path(self.pom_xml_file)
-        self.mkdocs_file = resolve_path(self.mkdocs_file)
-        self.rust_file = resolve_path(self.rust_file)
-        self.cff_file = resolve_path(self.cff_file)
-        self.codemeta_file = resolve_path(self.codemeta_file)
-        self.packages = resolve_path(self.packages)
+        for field in (
+            "pyproject_file",
+            "package_json_file",
+            "julia_file",
+            "fortran_file",
+            "pom_xml_file",
+            "mkdocs_file",
+            "rust_file",
+            "cff_file",
+            "codemeta_file",
+            "packages",
+        ):
+            resolved = resolve_path(getattr(self, field))
+            if resolved is not None:
+                setattr(self, field, resolved)
 
 
 # --------
@@ -400,6 +407,7 @@ class ContributorBaseModel(SomesyBaseModel):
     @property
     def full_name(self) -> str:
         """Return the name of the contributor."""
+        raise NotImplementedError
 
     def to_name_email_string(self) -> str:
         """Convert project metadata person object to poetry string for person format `full name <x@y.z>`."""
@@ -734,7 +742,7 @@ class ProjectMetadata(SomesyBaseModel):
     ] = None
 
     people: Annotated[
-        list[Person] | None,
+        list[Person],
         Field(
             description="Project authors, maintainers and contributors.",
             default_factory=list,
@@ -742,7 +750,7 @@ class ProjectMetadata(SomesyBaseModel):
     ]
 
     entities: Annotated[
-        list[Entity] | None,
+        list[Entity],
         Field(
             description="Project authors, maintainers and contributors as entities (organizations).",
             default_factory=list,
@@ -792,7 +800,7 @@ class SomesyInput(SomesyBaseModel):
         Field(description="Project metadata to be used and synchronized."),
     ]
     config: Annotated[
-        SomesyConfig | None,
+        SomesyConfig,
         Field(
             description="somesy tool configuration (matches CLI flags).",
             default_factory=lambda: SomesyConfig(),

--- a/src/somesy/core/models.py
+++ b/src/somesy/core/models.py
@@ -741,21 +741,15 @@ class ProjectMetadata(SomesyBaseModel):
         Field(min_length=1, description="Keywords that describe the project."),
     ] = None
 
-    people: Annotated[
-        list[Person],
-        Field(
-            description="Project authors, maintainers and contributors.",
-            default_factory=list,
-        ),
-    ]
+    people: list[Person] = Field(
+        default_factory=list,
+        description="Project authors, maintainers and contributors.",
+    )
 
-    entities: Annotated[
-        list[Entity],
-        Field(
-            description="Project authors, maintainers and contributors as entities (organizations).",
-            default_factory=list,
-        ),
-    ]
+    entities: list[Entity] = Field(
+        default_factory=list,
+        description="Project authors, maintainers and contributors as entities (organizations).",
+    )
 
     def authors(self):
         """Return people and entities explicitly marked as authors."""

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -2,6 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +15,7 @@ class IgnoreKey:
     """Special marker to be passed for dropping a key from serialization."""
 
 
-FieldKeyMapping = dict[str, list[str] | IgnoreKey]
+FieldKeyMapping = dict[str, str | list[str] | IgnoreKey]
 """Type to be used for the dict passed as `direct_mappings`."""
 
 DictLike = Any
@@ -109,7 +110,7 @@ class ProjectMetadataWriter(ABC):
 
     def _get_property(
         self,
-        key: str | list[str],
+        key: str | list[str] | IgnoreKey,
         *,
         only_first: bool = False,
         remove: bool = False,
@@ -125,9 +126,11 @@ class ProjectMetadataWriter(ABC):
             remove: If True, will remove the retrieved value and clean up the dict.
 
         """
+        if isinstance(key, IgnoreKey):
+            return None
         key_path = [key] if isinstance(key, str) else key
 
-        curr = self._data
+        curr: Any = self._data
         seq = [curr]
         for k in key_path:
             curr = curr.get(k)
@@ -179,7 +182,9 @@ class ProjectMetadataWriter(ABC):
     # special handling for person metadata
 
     def _merge_person_metadata(
-        self, old: list[Person | Entity], new: list[Person | Entity]
+        self,
+        old: Sequence[Person | Entity],
+        new: Sequence[Person | Entity],
     ) -> list[Person | Entity]:
         """Update metadata of a list of persons.
 
@@ -240,7 +245,7 @@ class ProjectMetadataWriter(ABC):
         return existing_modified + new_people
 
     def _sync_person_list(
-        self, old: list[Any], new: list[Person | Entity]
+        self, old: list[Any], new: Sequence[Person | Entity]
     ) -> list[Any]:
         """Sync a list of persons with new metadata.
 
@@ -256,7 +261,7 @@ class ProjectMetadataWriter(ABC):
 
         # check if people are unique
         def filter_unique(
-            people: list[Person | Entity],
+            people: Sequence[Person | Entity],
         ) -> list[Person | Entity]:
             """Filter out duplicate people from a list."""
             if people is None or len(people) == 0:
@@ -340,7 +345,10 @@ class ProjectMetadataWriter(ABC):
                 updates = {"author": True} if role == "authors" else {}
                 updates.update({"maintainer": True} if role == "maintainers" else {})
                 person = person.model_copy(update=updates)
-                (entities if isinstance(person, Entity) else people).append(person)
+                if isinstance(person, Entity):
+                    entities.append(person)
+                else:
+                    people.append(person)
 
         if people:
             data["people"] = people
@@ -372,7 +380,7 @@ class ProjectMetadataWriter(ABC):
     # ----
     # individual magic getters and setters
 
-    def _get_key(self, key):
+    def _get_key(self, key: str) -> str | list[str] | IgnoreKey:
         """Get a key itself."""
         return self.direct_mappings.get(key) or key
 

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -313,6 +313,41 @@ class ProjectMetadataWriter(ABC):
             str(metadata.documentation) if metadata.documentation else None
         )
 
+    def harvest_metadata(self) -> dict[str, Any]:
+        """Return metadata read from this endpoint in Somesy model terms."""
+        data: dict[str, Any] = {}
+        for field in (
+            "name",
+            "version",
+            "description",
+            "license",
+            "homepage",
+            "repository",
+            "documentation",
+            "keywords",
+        ):
+            try:
+                value = getattr(self, field)
+            except (KeyError, TypeError):
+                continue
+            if value not in (None, [], ""):
+                data[field] = value
+
+        people: list[Person] = []
+        entities: list[Entity] = []
+        for role in ("authors", "maintainers", "contributors"):
+            for person in self._parse_people(getattr(self, role) or []):
+                updates = {"author": True} if role == "authors" else {}
+                updates.update({"maintainer": True} if role == "maintainers" else {})
+                person = person.model_copy(update=updates)
+                (entities if isinstance(person, Entity) else people).append(person)
+
+        if people:
+            data["people"] = people
+        if entities:
+            data["entities"] = entities
+        return data
+
     @staticmethod
     @abstractmethod
     def _from_person(person: Person | Entity) -> Any:

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -35,7 +35,7 @@ class ProjectMetadataWriter(ABC):
         path: Path,
         *,
         create_if_not_exists: bool | None = False,
-        direct_mappings: FieldKeyMapping = None,
+        direct_mappings: FieldKeyMapping | None = None,
         merge: bool | None = False,
         pass_validation: bool | None = False,
     ) -> None:
@@ -113,7 +113,7 @@ class ProjectMetadataWriter(ABC):
         *,
         only_first: bool = False,
         remove: bool = False,
-    ) -> Any | None:
+    ) -> Any:
         """Get a property from the data.
 
         Override this to e.g. rewrite the retrieved key
@@ -355,17 +355,19 @@ class ProjectMetadataWriter(ABC):
 
     @staticmethod
     @abstractmethod
-    def _to_person(person_obj: Any) -> Person | Entity:
+    def _to_person(person_obj: Any) -> Person | Entity | None:
         """Convert an object representing a person into a `Person` or `Entity` object."""
 
     @classmethod
     def _parse_people(cls, people: list[Any] | None) -> list[Person | Entity]:
         """Return a list of Persons and Entities parsed from list of format-specific people representations."""
         # remove None values
-        people = [p for p in people if p is not None]
-
-        people = [cls._to_person(p) for p in people or []]
-        return people
+        return [
+            person
+            for p in people or []
+            if p is not None
+            if (person := cls._to_person(p)) is not None
+        ]
 
     # ----
     # individual magic getters and setters
@@ -390,7 +392,7 @@ class ProjectMetadataWriter(ABC):
         return self._get_property(self._get_key("version"))
 
     @version.setter
-    def version(self, version: str) -> None:
+    def version(self, version: str | None) -> None:
         """Set the version of the project."""
         self._set_property(self._get_key("version"), version)
 
@@ -466,12 +468,12 @@ class ProjectMetadataWriter(ABC):
         self._set_property(self._get_key("keywords"), keywords)
 
     @property
-    def license(self) -> str | list[str] | None:
+    def license(self) -> Any:
         """Return the license of the project."""
         return self._get_property(self._get_key("license"))
 
     @license.setter
-    def license(self, license: str | list[str] | None) -> None:
+    def license(self, license: Any) -> None:
         """Set the license of the project."""
         self._set_property(self._get_key("license"), license)
 

--- a/src/somesy/fortran/writer.py
+++ b/src/somesy/fortran/writer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import tomlkit
 from rich.pretty import pretty_repr
+from tomlkit.items import InlineTable
 
 from somesy.core.models import Entity, Person, ProjectMetadata
 from somesy.core.writer import FieldKeyMapping, IgnoreKey, ProjectMetadataWriter
@@ -65,8 +66,8 @@ class Fortran(ProjectMetadataWriter):
     @maintainers.setter
     def maintainers(self, maintainers: list[Person | Entity]) -> None:
         """Set the maintainers of the project."""
-        maintainers = self._from_person(maintainers[0])
-        self._set_property(self._get_key("maintainers"), maintainers)
+        maintainer = self._from_person(maintainers[0])
+        self._set_property(self._get_key("maintainers"), maintainer)
 
     def _load(self) -> None:
         """Load fpm.toml file."""
@@ -103,7 +104,7 @@ class Fortran(ProjectMetadataWriter):
                 array.multiline(True)
                 # Ensure whitespace after commas in inline tables
                 for item in array:
-                    if isinstance(item, tomlkit.items.InlineTable):
+                    if isinstance(item, InlineTable):
                         # Rebuild the inline table with desired formatting
                         formatted_item = tomlkit.inline_table()
                         for k, v in item.value.items():
@@ -123,17 +124,17 @@ class Fortran(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person: str) -> Person | Entity | None:
+    def _to_person(person_obj: str) -> Person | Entity | None:
         """Convert from free string to person or entity object."""
         try:
-            return Person.from_name_email_string(person)
+            return Person.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.info(f"Cannot convert {person} to Person object, trying Entity.")
+            logger.info(f"Cannot convert {person_obj} to Person object, trying Entity.")
 
         try:
-            return Entity.from_name_email_string(person)
+            return Entity.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.warning(f"Cannot convert {person} to Entity.")
+            logger.warning(f"Cannot convert {person_obj} to Entity.")
             return None
 
     def sync(self, metadata: ProjectMetadata) -> None:

--- a/src/somesy/git/__init__.py
+++ b/src/somesy/git/__init__.py
@@ -1,0 +1,6 @@
+"""Git metadata harvesting."""
+
+from .harvest import harvest
+from .models import GitAuthor, GitMetadata
+
+__all__ = ["GitAuthor", "GitMetadata", "harvest"]

--- a/src/somesy/git/harvest.py
+++ b/src/somesy/git/harvest.py
@@ -1,0 +1,79 @@
+"""Harvest project metadata from a Git repository."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+from .models import GitAuthor, GitMetadata
+
+
+def _git(path: Path, *args: str) -> str:
+    """Run Git without invoking a shell."""
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("Git executable not found")
+    result = subprocess.run(  # noqa: S603 - arguments are fixed internal Git commands
+        [git, *args],
+        cwd=path,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _remote(path: Path) -> str | None:
+    """Return the origin URL, or the first configured remote URL."""
+    try:
+        return _git(path, "remote", "get-url", "origin")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        try:
+            remotes = _git(path, "remote").splitlines()
+            return _git(path, "remote", "get-url", remotes[0]) if remotes else None
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+
+
+def _authors(path: Path) -> list[GitAuthor]:
+    """Return all distinct mailmap-aware Git authors, ranked by commit count."""
+    try:
+        raw = _git(path, "log", "--all", "--format=%aN%x00%aE")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    identities = []
+    for record in raw.splitlines():
+        name, _, email = record.partition("\x00")
+        if name:
+            identities.append((name, email or None))
+
+    counts = Counter(identities)
+    return [
+        GitAuthor(name=name, email=email, commit_count=count)
+        for (name, email), count in sorted(
+            counts.items(), key=lambda item: (-item[1], item[0])
+        )
+    ]
+
+
+def harvest(path: Path = Path.cwd()) -> GitMetadata | None:
+    """Harvest Somesy-relevant metadata from ``path`` if it is a Git repository."""
+    try:
+        root = Path(_git(path, "rev-parse", "--show-toplevel"))
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    try:
+        version = _git(root, "describe", "--tags", "--abbrev=0") or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        version = None
+
+    return GitMetadata(
+        name=root.name,
+        repository=_remote(root),
+        version=version,
+        authors=_authors(root),
+    )

--- a/src/somesy/git/models.py
+++ b/src/somesy/git/models.py
@@ -1,0 +1,31 @@
+"""Models for metadata harvested from Git."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+from somesy.core.models import SomesyBaseModel
+from somesy.core.types import ContributionTypeEnum
+
+
+class GitAuthor(SomesyBaseModel):
+    """A Git author mapped to a Somesy project contributor."""
+
+    name: str
+    email: str | None = None
+    commit_count: Annotated[int, Field(ge=0)] = 0
+    author: bool = True
+    contribution_types: list[ContributionTypeEnum] = Field(
+        default_factory=lambda: [ContributionTypeEnum.code], min_length=1
+    )
+
+
+class GitMetadata(SomesyBaseModel):
+    """Git values that map to Somesy project metadata."""
+
+    name: str | None = None
+    repository: str | None = None
+    version: str | None = None
+    authors: list[GitAuthor] = Field(default_factory=list)

--- a/src/somesy/harvest.py
+++ b/src/somesy/harvest.py
@@ -1,0 +1,42 @@
+"""Harvest metadata from supported project files."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from somesy.fortran.writer import Fortran
+from somesy.julia.writer import Julia
+from somesy.mkdocs.writer import MkDocs
+from somesy.package_json.writer import PackageJSON
+from somesy.pom_xml.writer import POM
+from somesy.pyproject.writer import Pyproject
+from somesy.rust.writer import Rust
+
+logger = logging.getLogger("somesy")
+
+_SOURCES = (
+    ("pyproject.toml", Pyproject),
+    ("package.json", PackageJSON),
+    ("Project.toml", Julia),
+    ("fpm.toml", Fortran),
+    ("Cargo.toml", Rust),
+    ("pom.xml", POM),
+    ("mkdocs.yml", MkDocs),
+)
+
+
+def harvest_sources(root: Path) -> list[tuple[Path, dict[str, Any]]]:
+    """Read all supported non-generated metadata files under ``root``."""
+    sources = []
+    for filename, writer_cls in _SOURCES:
+        path = root / filename
+        if not path.is_file():
+            continue
+        try:
+            writer = writer_cls(path, pass_validation=True)
+            sources.append((path, writer.harvest_metadata()))
+        except (FileNotFoundError, KeyError, TypeError, ValueError) as error:
+            logger.warning("Cannot harvest metadata from %s: %s", path, error)
+    return sources

--- a/src/somesy/julia/writer.py
+++ b/src/somesy/julia/writer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import tomlkit
 from rich.pretty import pretty_repr
+from tomlkit.items import InlineTable
 
 from somesy.core.models import Entity, Person, ProjectMetadata
 from somesy.core.writer import ProjectMetadataWriter
@@ -67,7 +68,7 @@ class Julia(ProjectMetadataWriter):
                 array.multiline(True)
                 # Ensure whitespace after commas in inline tables
                 for item in array:
-                    if isinstance(item, tomlkit.items.InlineTable):
+                    if isinstance(item, InlineTable):
                         # Rebuild the inline table with desired formatting
                         formatted_item = tomlkit.inline_table()
                         for k, v in item.value.items():
@@ -87,17 +88,17 @@ class Julia(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person: str) -> Person | None:
+    def _to_person(person_obj: str) -> Person | Entity | None:
         """Convert from free string to person or entity object."""
         try:
-            return Person.from_name_email_string(person)
+            return Person.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.info(f"Cannot convert {person} to Person object, trying Entity.")
+            logger.info(f"Cannot convert {person_obj} to Person object, trying Entity.")
 
         try:
-            return Entity.from_name_email_string(person)
+            return Entity.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.warning(f"Cannot convert {person} to Entity.")
+            logger.warning(f"Cannot convert {person_obj} to Entity.")
             return None
 
     def sync(self, metadata: ProjectMetadata) -> None:

--- a/src/somesy/merge.py
+++ b/src/somesy/merge.py
@@ -1,0 +1,152 @@
+"""Merge harvested metadata into the canonical Somesy project model."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from somesy.core.models import Entity, Person, ProjectMetadata
+from somesy.git.models import GitAuthor, GitMetadata
+
+logger = logging.getLogger("somesy")
+
+_SCALAR_FIELDS = (
+    "name",
+    "version",
+    "description",
+    "license",
+    "homepage",
+    "repository",
+    "documentation",
+)
+
+
+def _value(value: Any) -> Any:
+    """Convert common endpoint wrapper values to project-model values."""
+    if hasattr(value, "text"):
+        return value.text
+    if isinstance(value, (set, tuple)):
+        return list(value)
+    if isinstance(value, list):
+        return [_value(item) for item in value]
+    return getattr(value, "value", value)
+
+
+def _repository(value: Any) -> str | None:
+    """Return a repository URL acceptable to ProjectMetadata when possible."""
+    value = _value(value)
+    if not isinstance(value, str):
+        return None
+    if match := re.fullmatch(r"git@([^:]+):(.+)", value):
+        return f"https://{match[1]}/{match[2]}"
+    if value.startswith("ssh://git@"):
+        return "https://" + value.removeprefix("ssh://git@")
+    return value
+
+
+def _merge_person(existing: Person | Entity, incoming: Person | Entity):
+    """Fill missing fields and combine roles for one matching person."""
+    updates: dict[str, Any] = {}
+    for field in type(existing).model_fields:
+        old = getattr(existing, field)
+        new = getattr(incoming, field)
+        if field == "contribution_types":
+            values = list(dict.fromkeys((old or []) + (new or [])))
+            if values != (old or []):
+                updates[field] = values
+        elif field in {"author", "maintainer"}:
+            if new and not old:
+                updates[field] = True
+        elif field == "publication_author":
+            if new is True and old is not True:
+                updates[field] = True
+            elif old is None and new is not None:
+                updates[field] = new
+        elif old in (None, "") and new not in (None, ""):
+            updates[field] = new
+    return existing.model_copy(update=updates) if updates else existing
+
+
+def _merge_people(
+    existing: list[Person | Entity], incoming: Iterable[Person | Entity]
+) -> list[Person | Entity]:
+    """Merge people using the model's existing identity heuristics."""
+    result = list(existing)
+    for candidate in incoming:
+        for index, person in enumerate(result):
+            same_person = (
+                isinstance(person, Person)
+                and isinstance(candidate, Person)
+                and person.same_person(candidate)
+            )
+            same_entity = (
+                isinstance(person, Entity)
+                and isinstance(candidate, Entity)
+                and person.same_person(candidate)
+            )
+            if same_person or same_entity:
+                result[index] = _merge_person(person, candidate)
+                break
+        else:
+            result.append(candidate)
+    return result
+
+
+def _git_person(author: GitAuthor) -> Person | None:
+    """Convert a Git author into a Somesy Person."""
+    identity = author.name
+    if author.email:
+        identity = f"{identity} <{author.email}>"
+    try:
+        return Person.from_name_email_string(identity).model_copy(
+            update={
+                "author": author.author,
+                "contribution_types": author.contribution_types,
+            }
+        )
+    except (IndexError, ValueError):
+        logger.warning("Cannot convert Git author '%s' to Somesy metadata.", identity)
+        return None
+
+
+def merge_metadata(
+    sources: Iterable[dict[str, Any]], git: GitMetadata | None = None
+) -> ProjectMetadata:
+    """Merge harvested endpoint data and Git data into ProjectMetadata."""
+    data: dict[str, Any] = {"people": [], "entities": []}
+    keywords: list[str] = []
+
+    candidates = list(sources)
+    if git is not None:
+        candidates.append(git.model_dump(exclude_none=True))
+
+    for source in candidates:
+        for field in _SCALAR_FIELDS:
+            value = source.get(field)
+            if field == "repository":
+                value = _repository(value)
+            else:
+                value = _value(value)
+            if value not in (None, "") and field not in data:
+                data[field] = value
+
+        for keyword in _value(source.get("keywords", [])) or []:
+            if keyword not in keywords:
+                keywords.append(keyword)
+
+        people = source.get("people", []) or []
+        entities = source.get("entities", []) or []
+        data["people"] = _merge_people(data["people"], people)
+        data["entities"] = _merge_people(data["entities"], entities)
+
+        for author in source.get("authors", []) or []:
+            if isinstance(author, dict):
+                author = GitAuthor(**author)
+            if person := _git_person(author):
+                data["people"] = _merge_people(data["people"], [person])
+
+    if keywords:
+        data["keywords"] = keywords
+    return ProjectMetadata(**data)

--- a/src/somesy/mkdocs/writer.py
+++ b/src/somesy/mkdocs/writer.py
@@ -91,8 +91,8 @@ class MkDocs(ProjectMetadataWriter):
     @authors.setter
     def authors(self, authors: list[Entity | Person]) -> None:
         """Set the authors of the project."""
-        authors = self._from_person(authors[0])
-        self._set_property(self._get_key("authors"), authors)
+        author = self._from_person(authors[0])
+        self._set_property(self._get_key("authors"), author)
 
     @staticmethod
     def _from_person(person: Entity | Person):
@@ -100,17 +100,17 @@ class MkDocs(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person: str) -> Entity | Person | None:
+    def _to_person(person_obj: str) -> Entity | Person | None:
         """MkDocs Person is a string with full name."""
         try:
-            return Person.from_name_email_string(person)
+            return Person.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.info(f"Cannot convert {person} to Person object, trying Entity.")
+            logger.info(f"Cannot convert {person_obj} to Person object, trying Entity.")
 
         try:
-            return Entity.from_name_email_string(person)
+            return Entity.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.warning(f"Cannot convert {person} to Entity.")
+            logger.warning(f"Cannot convert {person_obj} to Entity.")
             return None
 
     def sync(self, metadata: ProjectMetadata) -> None:

--- a/src/somesy/package_json/models.py
+++ b/src/somesy/package_json/models.py
@@ -82,7 +82,9 @@ class PackageJsonConfig(BaseModel):
         author_email = author_match[2]
         author_url = author_match[3]
 
-        return PackageAuthor(name=author_name, email=author_email, url=author_url)
+        return PackageAuthor.model_validate(
+            {"name": author_name, "email": author_email, "url": author_url}
+        )
 
     @field_validator("name")
     @classmethod

--- a/src/somesy/package_json/writer.py
+++ b/src/somesy/package_json/writer.py
@@ -149,17 +149,17 @@ class PackageJSON(ProjectMetadataWriter):
 
     @staticmethod
     def _to_person(
-        person: str | dict[str, Any] | PackageAuthor,
+        person_obj: str | dict[str, Any] | PackageAuthor,
     ) -> Entity | Person:
         """Convert package.json dict or str for person format to project metadata person object."""
-        if isinstance(person, str):
+        if isinstance(person_obj, str):
             # parse from package.json format
-            person = PackageJsonConfig.convert_author(person)
+            person_obj = PackageJsonConfig.convert_author(person_obj)
 
-        if isinstance(person, PackageAuthor):
-            person = person.model_dump(exclude_none=True)
+        if isinstance(person_obj, PackageAuthor):
+            person_obj = person_obj.model_dump(exclude_none=True)
 
-        person_dict: dict[str, Any] = person  # type: ignore
+        person_dict: dict[str, Any] = person_obj  # type: ignore
 
         if "name" in person_dict and " " in person_dict["name"]:
             names = [s.strip() for s in person_dict["name"].split()]

--- a/src/somesy/pom_xml/writer.py
+++ b/src/somesy/pom_xml/writer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from somesy.core.models import Entity, Person
-from somesy.core.writer import FieldKeyMapping, ProjectMetadataWriter
+from somesy.core.writer import FieldKeyMapping, IgnoreKey, ProjectMetadataWriter
 
 from . import POM_ROOT_ATRS, POM_URL
 from .xmlproxy import XMLProxy
@@ -68,12 +68,14 @@ class POM(ProjectMetadataWriter):
 
     def _get_property(
         self,
-        key: str | list[str],
+        key: str | list[str] | IgnoreKey,
         *,
         only_first: bool = False,
         remove: bool = False,
     ) -> Any | None:
         """Get (a) property by key."""
+        if isinstance(key, IgnoreKey):
+            return None
         elem = super()._get_property(key, only_first=only_first, remove=remove)
         if elem is not None:
             if isinstance(elem, list):
@@ -161,8 +163,8 @@ class POM(ProjectMetadataWriter):
     @authors.setter
     def authors(self, authors: list[Entity | Person]) -> None:
         """Set the authors of the project."""
-        authors = [self._from_person(c) for c in authors]
-        self._set_property(self._get_key("authors"), authors)
+        author_records = [self._from_person(c) for c in authors]
+        self._set_property(self._get_key("authors"), author_records)
 
     # contributors must be a list
     @property
@@ -186,7 +188,7 @@ class POM(ProjectMetadataWriter):
         return []
 
     @maintainers.setter
-    def maintainers(self, maintainers: list[Person]) -> None:
+    def maintainers(self, maintainers: list[Person | Entity]) -> None:
         """Set the maintainers of the project."""
 
     @property

--- a/src/somesy/pom_xml/xmlproxy.py
+++ b/src/somesy/pom_xml/xmlproxy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast, overload
 
 import defusedxml.ElementTree as DET
 
@@ -27,10 +27,11 @@ def indent(elem, level=0):
             elem.text = i + "  "
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
-        for el in elem:
-            indent(el, level + 1)
-        if not el.tail or not el.tail.strip():
-            el.tail = i
+        children = list(elem)
+        for child in children:
+            indent(child, level + 1)
+        if not children[-1].tail or not children[-1].tail.strip():
+            children[-1].tail = i
     else:
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
@@ -208,7 +209,7 @@ class XMLProxy:
     @classmethod
     def from_jsonlike(
         cls, val: JSONLike, *, root_name: str | None = None, **kwargs: Any
-    ):
+    ) -> Any:
         """Convert a JSON-like primitive, array or dict into an XML element.
 
         Note that booleans are serialized as `true`/`false` and None as `null`.
@@ -233,7 +234,9 @@ class XMLProxy:
                 elem.append(ET.Comment(v if isinstance(v, str) else str(v)))
 
             elif isinstance(v, list):
-                for vv in XMLProxy.from_jsonlike(v, root_name=k, **kwargs):
+                for vv in cast(
+                    list[XMLProxy], XMLProxy.from_jsonlike(v, root_name=k, **kwargs)
+                ):
                     elem.append(vv._node)
             elif not isinstance(v, dict):  # primitive val
                 # FIXME: use better case-splitting for type of function to avoid cast
@@ -243,13 +246,25 @@ class XMLProxy:
                 )
                 elem.append(tmp._node)
             else:  # dict
-                elem.append(XMLProxy.from_jsonlike(v, root_name=k)._node)
+                elem.append(
+                    cast(XMLProxy, XMLProxy.from_jsonlike(v, root_name=k))._node
+                )
 
         return cls(elem, **kwargs)
 
     # ---- dict-like access ----
 
-    def get(self, key: str, *, as_nodes: bool = False, deep: bool = False):
+    @overload
+    def get(
+        self, key: str, *, as_nodes: Literal[True], deep: Literal[False] = False
+    ) -> list[XMLProxy]: ...
+
+    @overload
+    def get(
+        self, key: str, *, as_nodes: Literal[False] = False, deep: bool = False
+    ) -> Any: ...
+
+    def get(self, key: str, *, as_nodes: bool = False, deep: bool = False) -> Any:
         """Get sub-structure(s) of value(s) matching desired XML tag name.
 
         * If there are multiple matching elements, will return them all as a list.
@@ -396,14 +411,14 @@ class XMLProxy:
             nodes.append(self._wrap(ET.SubElement(self._node, key_name)))
 
         # normalize values no XML element nodes
-        nvals = []
+        nvals: list[XMLProxy] = []
         for item in vals:
             # ensure value is represented as an XML node
             if isinstance(item, XMLProxy):
                 obj = self._wrap(ET.Element("dummy"))
                 obj._node.append(item._node)
             else:
-                obj = self.from_jsonlike(item, root_name=key_name)
+                obj = cast(XMLProxy, self.from_jsonlike(item, root_name=key_name))
 
             nvals.append(obj)
 

--- a/src/somesy/pom_xml/xmlproxy.py
+++ b/src/somesy/pom_xml/xmlproxy.py
@@ -83,7 +83,10 @@ class XMLProxy:
     def parse(cls, path: str | Path, **kwargs) -> XMLProxy:
         """Parse an XML file into a wrapped ElementTree, preserving comments."""
         path = path if isinstance(path, Path) else Path(path)
-        return cls(load_xml(path).getroot(), **kwargs)
+        root = load_xml(path).getroot()
+        if root is None:
+            raise ValueError(f"XML file has no root element: {path}")
+        return cls(root, **kwargs)
 
     def write(self, path: str | Path, *, header: bool = True, **kwargs):
         """Write the XML DOM to an UTF-8 encoded file."""
@@ -378,6 +381,8 @@ class XMLProxy:
             # ensure the target node is cleared out and use it as target
             key._clear()
             nodes = [key]
+            if key.tag is None:
+                raise ValueError("Cannot overwrite an XML element without a tag")
             key = key.tag
 
         # ensure key string is qualified with a namespace

--- a/src/somesy/pyproject/models.py
+++ b/src/somesy/pyproject/models.py
@@ -167,8 +167,10 @@ class PoetryConfig(BaseModel):
                         validated.append(author)
                     else:
                         logger.warning(f"Same person {author} is added multiple times.")
-            elif "@" in author and EMailAddress.validate_python(
-                author.split(" ")[-1][1:-1]
+            elif (
+                isinstance(author, str)
+                and "@" in author
+                and EMailAddress.validate_python(author.split(" ")[-1][1:-1])
             ):
                 validated.append(author)
             else:

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -61,7 +61,7 @@ class PyprojectCommon(ProjectMetadataWriter):
         return self._get_property(self._get_key("version"))
 
     @version.setter
-    def version(self, value: str) -> None:
+    def version(self, value: str | None) -> None:
         """Set version, skipping if listed as dynamic."""
         if "version" in self._dynamic_fields:
             if value:
@@ -115,7 +115,7 @@ class PyprojectCommon(ProjectMetadataWriter):
 
     def _get_property(
         self, key: str | list[str], *, remove: bool = False, **kwargs
-    ) -> Any | None:
+    ) -> Any:
         """Get a property from the pyproject.toml file."""
         key_path = [key] if isinstance(key, str) else key
         full_path = self._section + key_path
@@ -173,7 +173,7 @@ class Poetry(PyprojectCommon):
 
         See [somesy.core.writer.ProjectMetadataWriter.__init__][].
         """
-        self._poetry_version = version
+        self._poetry_version = version or 1
         v2_mappings = {
             "homepage": ["urls", "homepage"],
             "repository": ["urls", "repository"],

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -8,7 +8,9 @@ import tomlkit
 import wrapt
 from rich.pretty import pretty_repr
 from tomlkit import load
+from tomlkit.items import InlineTable
 
+from somesy.core.log import VERBOSE
 from somesy.core.models import Entity, Person, ProjectMetadata
 from somesy.core.writer import IgnoreKey, ProjectMetadataWriter
 
@@ -61,15 +63,15 @@ class PyprojectCommon(ProjectMetadataWriter):
         return self._get_property(self._get_key("version"))
 
     @version.setter
-    def version(self, value: str | None) -> None:
+    def version(self, version: str | None) -> None:
         """Set version, skipping if listed as dynamic."""
         if "version" in self._dynamic_fields:
-            if value:
+            if version:
                 logger.warning(
                     "Field 'version' is listed as dynamic — skipping sync from somesy."
                 )
             return
-        self._set_property(self._get_key("version"), value)
+        self._set_property(self._get_key("version"), version)
 
     @property
     def description(self) -> str | None:
@@ -77,15 +79,15 @@ class PyprojectCommon(ProjectMetadataWriter):
         return self._get_property(self._get_key("description"))
 
     @description.setter
-    def description(self, value: str) -> None:
+    def description(self, description: str) -> None:
         """Set description, skipping if listed as dynamic."""
         if "description" in self._dynamic_fields:
-            if value:
+            if description:
                 logger.warning(
                     "Field 'description' is listed as dynamic — skipping sync from somesy."
                 )
             return
-        self._set_property(self._get_key("description"), value)
+        self._set_property(self._get_key("description"), description)
 
     def _load(self) -> None:
         """Load pyproject.toml file."""
@@ -114,9 +116,11 @@ class PyprojectCommon(ProjectMetadataWriter):
             tomlkit.dump(self._data, f)
 
     def _get_property(
-        self, key: str | list[str], *, remove: bool = False, **kwargs
+        self, key: str | list[str] | IgnoreKey, *, remove: bool = False, **kwargs
     ) -> Any:
         """Get a property from the pyproject.toml file."""
+        if isinstance(key, IgnoreKey):
+            return None
         key_path = [key] if isinstance(key, str) else key
         full_path = self._section + key_path
         return super()._get_property(full_path, remove=remove, **kwargs)
@@ -148,7 +152,7 @@ class PyprojectCommon(ProjectMetadataWriter):
             array.multiline(True)
             # Ensure whitespace after commas in inline tables
             for item in array:
-                if isinstance(item, tomlkit.items.InlineTable):
+                if isinstance(item, InlineTable):
                     # Rebuild the inline table with desired formatting
                     formatted_item = tomlkit.inline_table()
                     for k, v in item.value.items():
@@ -209,23 +213,23 @@ class Poetry(PyprojectCommon):
 
     @staticmethod
     def _to_person(
-        person: str | dict[str, str],
+        person_obj: str | dict[str, str],
     ) -> Person | Entity | None:
         """Convert from free string to person or entity object."""
-        if isinstance(person, dict):
-            temp = str(person["name"])
-            if "email" in person:
-                temp = f"{temp} <{person['email']}>"
-            person = temp
+        if isinstance(person_obj, dict):
+            temp = str(person_obj["name"])
+            if "email" in person_obj:
+                temp = f"{temp} <{person_obj['email']}>"
+            person_obj = temp
         try:
-            return Person.from_name_email_string(person)
+            return Person.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.info(f"Cannot convert {person} to Person object, trying Entity.")
+            logger.info(f"Cannot convert {person_obj} to Person object, trying Entity.")
 
         try:
-            return Entity.from_name_email_string(person)
+            return Entity.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.warning(f"Cannot convert {person} to Entity.")
+            logger.warning(f"Cannot convert {person_obj} to Entity.")
             return None
 
     @property
@@ -241,13 +245,13 @@ class Poetry(PyprojectCommon):
         return raw_license
 
     @license.setter
-    def license(self, value: License | str) -> None:
+    def license(self, license: License | str) -> None:
         """Set license in pyproject.toml file."""
         # if version is 1, set license as str
         if self._poetry_version == 1:
-            self._set_property(["license"], value)
+            self._set_property(["license"], license)
         else:
-            self._set_property(["license"], value)
+            self._set_property(["license"], license)
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync metadata with pyproject.toml file."""
@@ -305,7 +309,7 @@ class SetupTools(PyprojectCommon):
         )
 
     @staticmethod
-    def _from_person(person: Person):
+    def _from_person(person: Person | Entity):
         """Convert project metadata person object to setuptools dict for person format."""
         response = {"name": person.full_name}
         if person.email:
@@ -313,25 +317,25 @@ class SetupTools(PyprojectCommon):
         return response
 
     @staticmethod
-    def _to_person(person: str | dict) -> Entity | Person | None:
+    def _to_person(person_obj: str | dict) -> Entity | Person | None:
         """Parse setuptools person string to a Person/Entity."""
         # NOTE: for our purposes, does not matter what are given or family names,
         # we only compare on full_name anyway.
-        if isinstance(person, dict):
-            temp = str(person["name"])
-            if "email" in person:
-                temp = f"{temp} <{person['email']}>"
-            person = temp
+        if isinstance(person_obj, dict):
+            temp = str(person_obj["name"])
+            if "email" in person_obj:
+                temp = f"{temp} <{person_obj['email']}>"
+            person_obj = temp
 
         try:
-            return Person.from_name_email_string(person)
+            return Person.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.info(f"Cannot convert {person} to Person object, trying Entity.")
+            logger.info(f"Cannot convert {person_obj} to Person object, trying Entity.")
 
         try:
-            return Entity.from_name_email_string(person)
+            return Entity.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.warning(f"Cannot convert {person} to Entity.")
+            logger.warning(f"Cannot convert {person_obj} to Entity.")
             return None
 
     def sync(self, metadata: ProjectMetadata) -> None:
@@ -373,16 +377,17 @@ class Pyproject(wrapt.ObjectProxy):
 
         if is_poetry:
             if has_project:
-                logger.verbose(
-                    "Found Poetry 2.x metadata with project section in pyproject.toml"
+                logger.log(
+                    VERBOSE,
+                    "Found Poetry 2.x metadata with project section in pyproject.toml",
                 )
             else:
-                logger.verbose("Found Poetry 1.x metadata in pyproject.toml")
+                logger.log(VERBOSE, "Found Poetry 1.x metadata in pyproject.toml")
             self.__wrapped__ = Poetry(
                 path, pass_validation=pass_validation, version=2 if has_project else 1
             )
         elif has_project and not is_poetry:
-            logger.verbose("Found setuptools-based metadata in pyproject.toml")
+            logger.log(VERBOSE, "Found setuptools-based metadata in pyproject.toml")
             self.__wrapped__ = SetupTools(path, pass_validation=pass_validation)
         else:
             msg = "The pyproject.toml file is ambiguous. For Poetry projects, ensure [tool.poetry] section exists. For setuptools, ensure [project] section exists without [tool.poetry]"

--- a/src/somesy/rust/models.py
+++ b/src/somesy/rust/models.py
@@ -101,10 +101,10 @@ class RustConfig(BaseModel):
             return v
 
         # Check if number of keywords is at most 5
-        if v is not None and len(v) > 5:
+        if len(v) > 5:
             raise ValueError("A maximum of 5 keywords is allowed")
 
-        for keyword in v:
+        for keyword in v or []:
             check_keyword(keyword)
 
         return v

--- a/src/somesy/rust/writer.py
+++ b/src/somesy/rust/writer.py
@@ -74,7 +74,7 @@ class Rust(ProjectMetadataWriter):
 
     def _get_property(
         self, key: str | list[str] | IgnoreKey, *, remove: bool = False, **kwargs
-    ) -> Any | None:
+    ) -> Any:
         """Get a property from the Cargo.toml file."""
         if isinstance(key, IgnoreKey):
             return None

--- a/src/somesy/rust/writer.py
+++ b/src/somesy/rust/writer.py
@@ -126,24 +126,24 @@ class Rust(ProjectMetadataWriter):
         return person.to_name_email_string()
 
     @staticmethod
-    def _to_person(person: str) -> Person | Entity | None:
+    def _to_person(person_obj: str) -> Person | Entity | None:
         """Parse rust person string to a Person. It has format "full name <email>." but email is optional.
 
         Since there is no way to know whether this entry is a person or an entity, we will directly convert to Person.
         """
         try:
-            return Person.from_name_email_string(person)
+            return Person.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.info(f"Cannot convert {person} to Person object, trying Entity.")
+            logger.info(f"Cannot convert {person_obj} to Person object, trying Entity.")
 
         try:
-            return Entity.from_name_email_string(person)
+            return Entity.from_name_email_string(person_obj)
         except (ValueError, AttributeError):
-            logger.warning(f"Cannot convert {person} to Entity.")
+            logger.warning(f"Cannot convert {person_obj} to Entity.")
             return None
 
     @classmethod
-    def _parse_people(cls, people: list[Any] | None) -> list[Person]:
+    def _parse_people(cls, people: list[Any] | None) -> list[Person | Entity]:
         """Return a list of Persons parsed from list of format-specific people representations. to_person can return None, so filter out None values."""
         return list(filter(None, map(cls._to_person, people or [])))
 

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -1,0 +1,83 @@
+"""Tests for the metadata initialization command."""
+
+import subprocess
+
+from typer.testing import CliRunner
+
+from somesy.core.core import get_input_content
+from somesy.main import app
+
+runner = CliRunner()
+
+
+def test_init_harvests_project_file_and_git_authors(
+    tmp_path, create_files, file_types, monkeypatch
+):
+    """Create Somesy metadata from a project file and Git history."""
+    create_files({(file_types.POETRY, "pyproject.toml")})
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Git Author"], cwd=tmp_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "git@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"], cwd=tmp_path, check=True
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=tmp_path, check=True)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["init"])
+
+    assert result.exit_code == 0, result.stdout
+    content = get_input_content(tmp_path / "somesy.toml")
+    assert content["project"]["name"] == "test-package"
+    assert any(
+        person["email"] == "git@example.com" for person in content["project"]["people"]
+    )
+
+
+def test_init_prompts_for_missing_required_metadata(tmp_path, monkeypatch):
+    """Prompt only for required fields absent from harvested metadata."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("somesy.cli.init.harvest_sources", lambda _: [])
+    monkeypatch.setattr("somesy.cli.init.harvest_git", lambda _: None)
+
+    result = runner.invoke(
+        app,
+        ["init"],
+        input="example\nA project\nMIT\nperson\nJane\nDoe\n\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    content = get_input_content(tmp_path / "somesy.toml")
+    assert content["project"]["name"] == "example"
+    assert content["project"]["license"] == "MIT"
+    assert content["project"]["people"][0]["given-names"] == "Jane"
+
+
+def test_init_prompts_for_entity_author_and_partial_metadata(tmp_path, monkeypatch):
+    """Prompt only for missing fields and support an organization author."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "somesy.cli.init.harvest_sources",
+        lambda _: [(tmp_path / "pyproject.toml", {"name": "harvested"})],
+    )
+    monkeypatch.setattr("somesy.cli.init.harvest_git", lambda _: None)
+
+    result = runner.invoke(
+        app,
+        ["init"],
+        input="A project\nMIT\nentity\nExample Org\norg@example.com\n",
+    )
+
+    assert result.exit_code == 0, result.stdout
+    content = get_input_content(tmp_path / "somesy.toml")
+    assert content["project"]["name"] == "harvested"
+    assert content["project"]["description"] == "A project"
+    assert content["project"]["entities"][0]["name"] == "Example Org"
+    assert content["project"]["entities"][0]["email"] == "org@example.com"

--- a/tests/commands/test_sync.py
+++ b/tests/commands/test_sync.py
@@ -3,8 +3,13 @@
 from pathlib import Path
 
 from somesy.commands.sync import _sync_file, sync
-from somesy.core.models import SomesyInput, SomesyConfig, ProjectMetadata
-from somesy.core.models import Person, LicenseEnum
+from somesy.core.models import (
+    LicenseEnum,
+    Person,
+    ProjectMetadata,
+    SomesyConfig,
+    SomesyInput,
+)
 
 
 def test_sync_file_does_not_rewrite_unchanged_data(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,18 @@
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Set, Tuple, Type
+from typing import Any
 
 import pytest
 
 from somesy.cff import CFF
 from somesy.core.log import SomesyLogLevel, set_log_level
 from somesy.core.models import Entity, Person, SomesyInput
-from somesy.package_json.writer import PackageJSON
-from somesy.pyproject import Pyproject
-from somesy.julia import Julia
 from somesy.fortran import Fortran
-from somesy.pom_xml.writer import POM
+from somesy.julia import Julia
 from somesy.mkdocs import MkDocs
+from somesy.package_json.writer import PackageJSON
+from somesy.pom_xml.writer import POM
+from somesy.pyproject import Pyproject
 from somesy.rust import Rust
 
 TEST_DIR = Path(__file__).resolve().parent
@@ -47,7 +47,7 @@ def somesy_input() -> SomesyInput:
 
 
 @pytest.fixture
-def file_types() -> Type[FileTypes]:
+def file_types() -> type[FileTypes]:
     """Return a FileTypes instance."""
     return FileTypes
 
@@ -62,9 +62,10 @@ def create_files(tmp_path):
     # file_dir folder has the requested files
     file_dir = create_files(files)
     ```
+
     """
 
-    def _create_files(files: Set[Tuple[FileTypes, str]]):
+    def _create_files(files: set[tuple[FileTypes, str]]):
         for file_tuple in files:
             file_type, file_name = file_tuple
             if not isinstance(file_type, FileTypes):
@@ -74,7 +75,7 @@ def create_files(tmp_path):
             write_file_name.parent.mkdir(parents=True, exist_ok=True)
 
             read_file_path = Path("tests/data")
-            read_file_name: Path = None
+            read_file_name: Path | None = None
             # set file name as the input, if not given set to default
             if file_type == FileTypes.CITATION:
                 read_file_name = read_file_path / Path("CITATION.cff")
@@ -119,10 +120,11 @@ def load_files():
     # file_instances dict has the instances of the requested files
     file_instances = load_files(files)
     ```
+
     """
 
-    def _load_files(files: Set[FileTypes]):
-        file_instances: Dict[FileTypes, Any] = {}
+    def _load_files(files: set[FileTypes]):
+        file_instances: dict[FileTypes, Any] = {}
         for file_type in files:
             if not isinstance(file_type, FileTypes):
                 raise ValueError(f"Invalid file type: {file_type}")

--- a/tests/git/test_harvest.py
+++ b/tests/git/test_harvest.py
@@ -1,0 +1,40 @@
+"""Tests for Git metadata harvesting."""
+
+import subprocess
+
+from somesy.git import harvest
+
+
+def git(path, *args):
+    return subprocess.run(
+        ["git", *args], cwd=path, check=True, capture_output=True, text=True
+    )
+
+
+def test_harvest_returns_somesy_relevant_metadata(tmp_path):
+    git(tmp_path, "init", "-q")
+    git(tmp_path, "config", "user.name", "Jane Doe")
+    git(tmp_path, "config", "user.email", "jane@example.com")
+    git(tmp_path, "config", "commit.gpgsign", "false")
+    (tmp_path / "README.md").write_text("project")
+    git(tmp_path, "add", "README.md")
+    git(tmp_path, "commit", "-qm", "initial")
+    git(tmp_path, "tag", "v1.2.0")
+    (tmp_path / "README.md").write_text("project\nupdated")
+    git(tmp_path, "commit", "-qam", "update")
+
+    metadata = harvest(tmp_path)
+
+    assert metadata is not None
+    assert metadata.name == tmp_path.name
+    assert metadata.repository is None
+    assert metadata.version == "v1.2.0"
+    assert metadata.authors[0].name == "Jane Doe"
+    assert metadata.authors[0].email == "jane@example.com"
+    assert metadata.authors[0].commit_count == 2
+    assert metadata.authors[0].author is True
+    assert [str(t) for t in metadata.authors[0].contribution_types] == ["code"]
+
+
+def test_harvest_returns_none_outside_git_repository(tmp_path):
+    assert harvest(tmp_path) is None

--- a/tests/git/test_models.py
+++ b/tests/git/test_models.py
@@ -1,0 +1,10 @@
+"""Tests for Git metadata models."""
+
+import pytest
+
+from somesy.git.models import GitAuthor
+
+
+def test_git_author_rejects_negative_commit_count():
+    with pytest.raises(ValueError):
+        GitAuthor(name="Jane Doe", commit_count=-1)

--- a/tests/harvest/test_sources.py
+++ b/tests/harvest/test_sources.py
@@ -1,0 +1,27 @@
+"""Tests for project-file metadata harvesting."""
+
+from somesy.harvest import harvest_sources
+
+
+def test_harvest_sources_uses_existing_endpoint_readers(
+    tmp_path, create_files, file_types
+):
+    create_files(
+        {
+            (file_types.POETRY, "pyproject.toml"),
+            (file_types.PACKAGE_JSON, "package.json"),
+        }
+    )
+
+    sources = harvest_sources(tmp_path)
+
+    assert [path.name for path, _ in sources] == ["pyproject.toml", "package.json"]
+    assert sources[0][1]["name"] == "test-package"
+    assert sources[0][1]["people"][0].author is True
+    assert sources[1][1]["name"] == "test-package"
+
+
+def test_harvest_sources_ignores_generated_metadata(tmp_path, create_files, file_types):
+    create_files({(file_types.CITATION, "CITATION.cff")})
+
+    assert harvest_sources(tmp_path) == []

--- a/tests/input/test_rust_validate.py
+++ b/tests/input/test_rust_validate.py
@@ -1,5 +1,5 @@
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 from tomlkit import dump
 
 from somesy.rust import Rust

--- a/tests/merge/test_merge.py
+++ b/tests/merge/test_merge.py
@@ -1,0 +1,123 @@
+"""Tests for harvested metadata merging."""
+
+import subprocess
+
+import pytest
+
+from somesy.core.models import Person
+from somesy.git.harvest import harvest
+from somesy.git.models import GitAuthor, GitMetadata
+from somesy.harvest import harvest_sources
+from somesy.merge import merge_metadata
+
+
+def test_merge_metadata_prefers_first_scalar_and_fills_people():
+    result = merge_metadata(
+        [
+            {
+                "name": "project",
+                "description": "description",
+                "license": "MIT",
+                "people": [
+                    Person(
+                        given_names="Jane",
+                        family_names="Doe",
+                        author=True,
+                    )
+                ],
+                "keywords": {"metadata"},
+            },
+            {
+                "name": "other-name",
+                "license": "Apache-2.0",
+                "people": [
+                    Person(
+                        given_names="Jane",
+                        family_names="Doe",
+                        email="jane@example.com",
+                        contribution_types=["code"],
+                    )
+                ],
+                "keywords": {"software"},
+            },
+        ]
+    )
+
+    assert result.name == "project"
+    assert str(result.license) == "MIT"
+    assert result.keywords == ["metadata", "software"]
+    assert len(result.people) == 1
+    assert result.people[0].email == "jane@example.com"
+    assert [str(value) for value in (result.people[0].contribution_types or [])] == [
+        "code"
+    ]
+
+
+def test_merge_metadata_adds_git_authors_as_code_authors():
+    result = merge_metadata(
+        [{"name": "project", "description": "description", "license": "MIT"}],
+        GitMetadata(
+            name="git-project",
+            repository="git@github.com:example/project.git",
+            version="v1.0.0",
+            authors=[GitAuthor(name="Jane Doe", email="jane@example.com")],
+        ),
+    )
+
+    assert str(result.repository) == "https://github.com/example/project.git"
+    assert result.version == "v1.0.0"
+    assert result.people[0].author is True
+    assert [str(value) for value in (result.people[0].contribution_types or [])] == [
+        "code"
+    ]
+
+
+def _commit(path, name, email, message):
+    subprocess.run(["git", "config", "user.name", name], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", email], cwd=path, check=True)
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", message], cwd=path, check=True)
+
+
+@pytest.mark.parametrize(
+    "file_types_to_create",
+    [
+        ["pyproject"],
+        ["package_json"],
+        ["pom"],
+        ["pyproject", "package_json"],
+    ],
+)
+def test_merge_real_endpoint_files_and_multiple_git_authors(
+    tmp_path, create_files, file_types, file_types_to_create
+):
+    type_map = {
+        "pyproject": (file_types.POETRY, "pyproject.toml"),
+        "package_json": (file_types.PACKAGE_JSON, "package.json"),
+        "pom": (file_types.POM_XML, "pom.xml"),
+    }
+    create_files({type_map[file_type] for file_type in file_types_to_create})
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"], cwd=tmp_path, check=True
+    )
+    _commit(tmp_path, "Git One", "one@example.com", "initial")
+    (tmp_path / "README.md").write_text("updated")
+    _commit(tmp_path, "Git Two", "two@example.com", "update")
+
+    result = merge_metadata(
+        [metadata for _, metadata in harvest_sources(tmp_path)], harvest(tmp_path)
+    )
+
+    assert result.name == "test-package"
+    assert {person.full_name for person in result.people} >= {"Git One", "Git Two"}
+    git_people = {
+        person.full_name: person
+        for person in result.people
+        if person.email in {"one@example.com", "two@example.com"}
+    }
+    assert all(person.author for person in git_people.values())
+    assert all(
+        [str(value) for value in (person.contribution_types or [])] == ["code"]
+        for person in git_people.values()
+    )

--- a/tests/output/test_cff_writer.py
+++ b/tests/output/test_cff_writer.py
@@ -1,7 +1,7 @@
 import pytest
 
 from somesy.cff.writer import CFF
-from somesy.core.models import LicenseEnum, Person, ProjectMetadata, Entity
+from somesy.core.models import Entity, LicenseEnum, Person, ProjectMetadata
 
 
 @pytest.fixture
@@ -123,13 +123,11 @@ def test_person_merge(tmp_path, person: Person, entity: Entity):
 
     # new person
     person3 = Person(
-        **{
-            "given_names": "Janice",
-            "family_names": "Doethan",
-            "email": "jane93@gmail.com",
-            "author": True,
-            "publication_author": True,
-        }
+        given_names="Janice",
+        family_names="Doethan",
+        email="jane93@gmail.com",
+        author=True,
+        publication_author=True,
     )
     # john has a new email address
     person1c = person1b.model_copy(update={"email": "john.of.us@qualityland.com"})

--- a/tests/output/test_fortran_writer.py
+++ b/tests/output/test_fortran_writer.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from somesy.core.models import LicenseEnum, Person, ProjectMetadata
+from somesy.core.models import LicenseEnum
 from somesy.fortran.writer import Fortran
 
 

--- a/tests/output/test_julia_writer.py
+++ b/tests/output/test_julia_writer.py
@@ -88,13 +88,11 @@ def test_person_merge(request, julia_file, person):
 
     # new person
     person3 = Person(
-        **{
-            "given_names": "Janice",
-            "family_names": "Doethan",
-            "email": "jane93@gmail.com",
-            "author": True,
-            "publication_author": True,
-        }
+        given_names="Janice",
+        family_names="Doethan",
+        email="jane93@gmail.com",
+        author=True,
+        publication_author=True,
     )
     person3_rep = Julia._from_person(person3)
 

--- a/tests/output/test_mkdocs_writer.py
+++ b/tests/output/test_mkdocs_writer.py
@@ -1,7 +1,7 @@
 import pytest
 
-from somesy.mkdocs import MkDocs
 from somesy.core.models import Person
+from somesy.mkdocs import MkDocs
 
 
 @pytest.fixture
@@ -38,4 +38,5 @@ def test_save(tmp_path):
 
 def test_from_person(person: Person):
     p = MkDocs._to_person(MkDocs._from_person(person))
+    assert p is not None
     assert p.to_name_email_string() == person.to_name_email_string()

--- a/tests/output/test_package_json_writer.py
+++ b/tests/output/test_package_json_writer.py
@@ -133,13 +133,11 @@ def test_person_merge(package_json_file, person: Person):
 
     # new person
     person3 = Person(
-        **{
-            "given_names": "Janice",
-            "family_names": "Doethan",
-            "email": "jane93@gmail.com",
-            "author": True,
-            "publication_author": True,
-        }
+        given_names="Janice",
+        family_names="Doethan",
+        email="jane93@gmail.com",
+        author=True,
+        publication_author=True,
     )
     # john has a new email address
     person1c = person1b.model_copy(update={"email": "john.of.us@qualityland.com"})

--- a/tests/output/test_pom_writer.py
+++ b/tests/output/test_pom_writer.py
@@ -1,7 +1,7 @@
 import pytest
 
-from somesy.pom_xml.writer import POM
 from somesy.core.models import LicenseEnum, Person, ProjectMetadata
+from somesy.pom_xml.writer import POM
 
 
 @pytest.fixture
@@ -127,13 +127,11 @@ def test_person_merge(pom_file, person: Person):
 
     # new person
     person3 = Person(
-        **{
-            "given_names": "Janice",
-            "family_names": "Doethan",
-            "email": "jane93@gmail.com",
-            "author": True,
-            "publication_author": True,
-        }
+        given_names="Janice",
+        family_names="Doethan",
+        email="jane93@gmail.com",
+        author=True,
+        publication_author=True,
     )
     # john has a new email address
     person1c = person1b.model_copy(update={"email": "john.of.us@qualityland.com"})

--- a/tests/output/test_pyproject_writer.py
+++ b/tests/output/test_pyproject_writer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from somesy.core.models import LicenseEnum, Person, ProjectMetadata, Entity
+from somesy.core.models import Entity, LicenseEnum, Person, ProjectMetadata
 from somesy.pyproject.writer import Poetry, SetupTools
 
 
@@ -215,13 +215,11 @@ def test_person_merge_pyproject(
 
     # new person
     person3 = Person(
-        **{
-            "given_names": "Janice",
-            "family_names": "Doethan",
-            "email": "jane93@gmail.com",
-            "author": True,
-            "publication_author": True,
-        }
+        given_names="Janice",
+        family_names="Doethan",
+        email="jane93@gmail.com",
+        author=True,
+        publication_author=True,
     )
     if version is not None:
         person3_rep = writer_class._from_person(person3, poetry_version=version)

--- a/tests/output/test_rust_writer.py
+++ b/tests/output/test_rust_writer.py
@@ -102,13 +102,11 @@ def test_person_merge(rust_file, person):
 
     # new person
     person3 = Person(
-        **{
-            "given_names": "Janice",
-            "family_names": "Doethan",
-            "email": "jane93@gmail.com",
-            "author": True,
-            "publication_author": True,
-        }
+        given_names="Janice",
+        family_names="Doethan",
+        email="jane93@gmail.com",
+        author=True,
+        publication_author=True,
     )
     person3_rep = Rust._from_person(person3)
 

--- a/tests/output/test_somesy_writer.py
+++ b/tests/output/test_somesy_writer.py
@@ -1,0 +1,40 @@
+"""Tests for writing standalone Somesy metadata."""
+
+import pytest
+
+from somesy.commands.init_config import write_somesy_file
+from somesy.core.core import get_input_content
+from somesy.core.models import LicenseEnum, Person, ProjectMetadata, SomesyInput
+
+
+def metadata():
+    """Return representative project metadata."""
+    return ProjectMetadata(
+        name="example",
+        description="An example project",
+        license=LicenseEnum.MIT,
+        people=[Person(given_names="Jane", family_names="Doe", author=True)],
+        keywords=["metadata"],
+    )
+
+
+def test_write_somesy_file_round_trips(tmp_path):
+    path = tmp_path / "somesy.toml"
+
+    write_somesy_file(metadata(), path)
+
+    loaded = SomesyInput(**get_input_content(path))
+    assert loaded.project.name == "example"
+    assert loaded.project.license == LicenseEnum.MIT
+    assert loaded.project.people[0].full_name == "Jane Doe"
+
+
+def test_write_somesy_file_refuses_to_overwrite(tmp_path):
+    path = tmp_path / "somesy.toml"
+    path.write_text("existing = true\n")
+
+    with pytest.raises(FileExistsError):
+        write_somesy_file(metadata(), path)
+
+    write_somesy_file(metadata(), path, overwrite=True)
+    assert "[project]" in path.read_text()

--- a/tests/processing/test_core_base_model.py
+++ b/tests/processing/test_core_base_model.py
@@ -1,5 +1,4 @@
 from pydantic import Field
-from typing import Optional
 
 from somesy.core.models import SomesyBaseModel
 
@@ -9,7 +8,7 @@ class SampleModel(SomesyBaseModel):
 
     name: str = Field(alias="full_name")
     age: int
-    email: Optional[str] = None
+    email: str | None = None
 
 
 def test_key_order():
@@ -137,7 +136,7 @@ def test_model_dump_with_none():
     model = SampleModel(full_name="John Doe", age=30, email=None)
     dumped = model.model_dump(exclude_none=False)
     # exclude default takes precedence so email should not be there
-    assert not "email" in dumped
+    assert "email" not in dumped
 
 
 def test_model_dump_json_with_none():

--- a/tests/processing/test_core_models.py
+++ b/tests/processing/test_core_models.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from somesy.core.models import Person, ProjectMetadata, Entity
+from somesy.core.models import Entity, Person, ProjectMetadata
 
 # dicts with test inputs for people
 p1 = {
@@ -34,6 +34,7 @@ e7 = {**e3, "rorid": e5["rorid"]}  # same rorid as e5
 def test_same_person():
     # same is same (reflexivity)
     assert Person(**p1).same_person(Person(**p1))
+
     # missing orcid, different mail, different name -> not same
     assert not Person(**p1).same_person(Person(**p2))
     # missing orcid, different mail, same name -> same

--- a/tests/processing/test_xmlwrapper.py
+++ b/tests/processing/test_xmlwrapper.py
@@ -1,7 +1,7 @@
+import pytest
+
 from somesy.pom_xml import POM_URL
 from somesy.pom_xml.xmlproxy import XMLProxy
-
-import pytest
 
 
 def test_parse_write(tmp_path, xml_examples):


### PR DESCRIPTION
## Summary

- Add `somesy init` to create a `somesy.toml` configuration.
- Harvest project metadata from supported source files.
- Harvest authors and contributors from Git history.
- Merge metadata from multiple sources into the common Somesy model.
- Prompt only for required metadata that could not be harvested.
- Configure synchronization based on detected source files.
- Add tests covering Git, `package.json`, `pyproject.toml`, and `pom.xml`.
- Add `pyright` hook

Closes #76
Closes #97
Closes #98