### PR TITLE
Add somesy set command and pre-commit integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please consult the changelog to inform yourself about breaking changes and secur
 - fix duplicate `-P` CLI shortcut warning in `somesy sync`
 - fix POM synchronization for people without email addresses
 - add `somesy init` to harvest metadata and create a project `somesy.toml`
+- add `somesy set` to update scalar project metadata in `somesy.toml`
 - add pyright hook
 
 ## [v0.7.3](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.7.3) <small>(2025-03-14)</small> { id="0.7.3" }

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ somesy init --output-file somesy.toml --overwrite
 
 For manual configuration of sync options, use `somesy init config`.
 
+Update a scalar project-metadata value with `somesy set`:
+
+```bash
+somesy set version 1.2.3
+```
+
 ### Using somesy
 
 Once somesy is installed and configured, somesy can take over and manage your project metadata.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -261,6 +261,19 @@ somesy init --overwrite
 Use `somesy init config` when you want to configure synchronization options
 manually instead of deriving them from the files in the project.
 
+### Update project metadata
+
+Use `somesy set` to update one scalar project-metadata value in an existing
+`somesy.toml` file:
+
+```bash
+somesy set version 1.2.3
+```
+
+The command supports `name`, `description`, `version`, `license`, `homepage`,
+`repository`, and `documentation`. It does not update structured values such as
+keywords, people, or entities.
+
 Without an input file specifically provided, somesy will check if it can find a valid
 
 -   `.somesy.toml`

--- a/src/somesy/cli/set_value.py
+++ b/src/somesy/cli/set_value.py
@@ -1,0 +1,20 @@
+"""Set project metadata in a somesy.toml file."""
+
+from pathlib import Path
+
+import typer
+
+from somesy.cli.util import existing_file_arg_config, wrap_exceptions
+from somesy.commands import set_project_value
+
+
+@wrap_exceptions
+def set_value(
+    field: str = typer.Argument(help="Project field to update."),
+    value: str = typer.Argument(help="New field value."),
+    input_file: Path = typer.Option(
+        Path("somesy.toml"), "--input-file", "-i", **existing_file_arg_config
+    ),
+):
+    """Set a scalar project-metadata value in somesy.toml."""
+    set_project_value(input_file, field, value)

--- a/src/somesy/commands/__init__.py
+++ b/src/somesy/commands/__init__.py
@@ -1,6 +1,7 @@
 """Commands for somesy."""
 
 from .init_config import init_config, write_somesy_file
+from .set_value import set_project_value
 from .sync import sync
 
-__all__ = ["init_config", "sync", "write_somesy_file"]
+__all__ = ["init_config", "set_project_value", "sync", "write_somesy_file"]

--- a/src/somesy/commands/set_value.py
+++ b/src/somesy/commands/set_value.py
@@ -1,0 +1,33 @@
+"""Update scalar project metadata in a somesy.toml file."""
+
+from pathlib import Path
+
+import tomlkit
+
+from somesy.core.core import get_input_content
+from somesy.core.models import ProjectMetadata, SomesyInput
+
+SETTABLE_FIELDS = {
+    "name",
+    "description",
+    "version",
+    "license",
+    "homepage",
+    "repository",
+    "documentation",
+}
+
+
+def set_project_value(input_file: Path, field: str, value: str) -> None:
+    """Set one scalar project-metadata value in a somesy.toml file."""
+    if field not in SETTABLE_FIELDS:
+        allowed = ", ".join(sorted(SETTABLE_FIELDS))
+        raise ValueError(f"Unknown project field '{field}'. Choose one of: {allowed}.")
+    if not SomesyInput.is_somesy_file_path(input_file):
+        raise ValueError("The input file must be a somesy.toml file.")
+
+    content = get_input_content(input_file, no_unwrap=True)
+    ProjectMetadata.model_validate({**content["project"], field: value})
+    content["project"][field] = value
+    with open(input_file, "w") as file:
+        tomlkit.dump(content, file)

--- a/src/somesy/main.py
+++ b/src/somesy/main.py
@@ -6,7 +6,7 @@ import sys
 import typer
 
 from somesy import __version__
-from somesy.cli import fill, init, sync
+from somesy.cli import fill, init, set_value, sync
 from somesy.core.log import SomesyLogLevel, init_log, set_log_level
 
 app = typer.Typer()
@@ -69,3 +69,4 @@ def common(
 app.add_typer(sync.app, name="sync")
 app.add_typer(init.app, name="init")
 app.add_typer(fill.app, name="fill")
+app.command("set")(set_value.set_value)

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -1,0 +1,82 @@
+"""Tests for the project metadata set command."""
+
+import pytest
+from typer.testing import CliRunner
+
+from somesy.commands import set_project_value
+from somesy.core.core import get_input_content
+from somesy.main import app
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("name", "renamed-project"),
+        ("description", "A revised description."),
+        ("version", "1.2.3"),
+        ("license", "MIT"),
+        ("homepage", "https://example.com"),
+        ("repository", "https://github.com/example/project"),
+        ("documentation", "https://docs.example.com"),
+    ],
+)
+def test_set_project_value(tmp_path, create_files, file_types, field, value):
+    """Update each supported scalar project value."""
+    create_files({(file_types.SOMESY, "somesy.toml")})
+    input_file = tmp_path / "somesy.toml"
+
+    set_project_value(input_file, field, value)
+
+    project = get_input_content(input_file)["project"]
+    assert project[field] == value
+    if field != "description":
+        assert (
+            project["description"]
+            == "This is a test project for demonstration purposes."
+        )
+
+
+def test_set_command_updates_project_value(
+    tmp_path, create_files, file_types, monkeypatch
+):
+    """Wire the command arguments to the project metadata update."""
+    create_files({(file_types.SOMESY, "somesy.toml")})
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["set", "name", "renamed-project"])
+
+    assert result.exit_code == 0, result.stdout
+    assert (
+        get_input_content(tmp_path / "somesy.toml")["project"]["name"]
+        == "renamed-project"
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "error"),
+    [
+        (["set", "keywords", "metadata"], "Unknown project field 'keywords'"),
+        (
+            ["set", "name", "renamed-project", "--input-file", "pyproject.toml"],
+            "The input file must be a somesy.toml file.",
+        ),
+    ],
+)
+def test_set_command_rejects_unsupported_input(
+    tmp_path, create_files, file_types, monkeypatch, arguments, error
+):
+    """Report invalid fields and input files through the Typer command."""
+    create_files(
+        {
+            (file_types.SOMESY, "somesy.toml"),
+            (file_types.POETRY, "pyproject.toml"),
+        }
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, arguments)
+
+    assert result.exit_code == 1
+    assert error in result.stdout

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -1,6 +1,5 @@
 """End-to-end tests for the Somesy pre-commit hook."""
 
-import json
 import shutil
 import subprocess
 import sys
@@ -27,8 +26,7 @@ def test_precommit_sync_requires_staging_generated_metadata(
         "    hooks:\n"
         "      - id: somesy\n"
         "        name: Run somesy sync\n"
-        "        entry: "
-        f"{json.dumps(f'{somesy} sync')}\n"
+        "        entry: somesy sync\n"
         "        language: system\n"
         "        files: ^somesy\\.toml$\n"
         "        pass_filenames: false\n"
@@ -61,6 +59,9 @@ def test_precommit_sync_requires_staging_generated_metadata(
     failed_hook = run(sys.executable, "-m", "pre_commit", "run", check=False)
     assert failed_hook.returncode == 1
     assert "Run somesy sync" in failed_hook.stdout
+    assert "version: 2.0.0" in (tmp_path / "CITATION.cff").read_text(), (
+        failed_hook.stdout + failed_hook.stderr
+    )
 
     run("git", "add", ".")
     committed = run("git", "commit", "-m", "update metadata", check=False)

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -1,0 +1,67 @@
+"""End-to-end tests for the Somesy pre-commit hook."""
+
+import json
+import shutil
+import subprocess
+import sys
+
+import tomlkit
+
+
+def test_precommit_sync_requires_staging_generated_metadata(
+    tmp_path, create_files, file_types
+):
+    """Fail after syncing changed metadata, then pass once generated files are staged."""
+    somesy = shutil.which("somesy")
+    assert somesy, "The somesy command must be available to test its hook."
+
+    create_files(
+        {
+            (file_types.SOMESY, "somesy.toml"),
+            (file_types.POETRY, "pyproject.toml"),
+        }
+    )
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: local\n"
+        "    hooks:\n"
+        "      - id: somesy\n"
+        "        name: Run somesy sync\n"
+        "        entry: "
+        f"{json.dumps(f'{somesy} sync')}\n"
+        "        language: system\n"
+        "        files: ^somesy\\.toml$\n"
+        "        pass_filenames: false\n"
+    )
+
+    def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            args,
+            cwd=tmp_path,
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+
+    run("git", "init", "-q")
+    run("git", "config", "user.name", "Test User")
+    run("git", "config", "user.email", "test@example.com")
+    run("git", "config", "commit.gpgsign", "false")
+    run(somesy, "sync")
+    run("git", "add", ".")
+    run("git", "commit", "-qm", "initial")
+    run(sys.executable, "-m", "pre_commit", "install")
+
+    input_file = tmp_path / "somesy.toml"
+    content = tomlkit.parse(input_file.read_text())
+    content["project"]["version"] = "2.0.0"
+    input_file.write_text(tomlkit.dumps(content))
+    run("git", "add", "somesy.toml")
+
+    failed_hook = run(sys.executable, "-m", "pre_commit", "run", check=False)
+    assert failed_hook.returncode == 1
+    assert "Run somesy sync" in failed_hook.stdout
+
+    run("git", "add", ".")
+    committed = run("git", "commit", "-m", "update metadata", check=False)
+    assert committed.returncode == 0, committed.stderr


### PR DESCRIPTION
## Summary

- add `somesy set` for updating scalar project metadata in `somesy.toml`
- document the command and add a v0.8.0 changelog entry
- add unit, Typer CLI, and pre-commit hook integration tests

Closes #88
Closes #47