### PR TITLE
Add Non-Interactive Project Initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Here we provide notes that summarize the most important changes in each released
 
 Please consult the changelog to inform yourself about breaking changes and security issues.
 
+## Unreleased
+
+- **Added**
+  - add `somesy init --non-interactive` for automated and batch initialization
+    - write the best available harvested metadata without prompting
+    - warn when required project metadata is missing
+    - allow partial generated metadata to be synchronized with an explicit
+      `--pass-validation` option or `pass_validation` config setting
+
 ## [v0.8.0](https://github.com/Materials-Data-Science-and-Informatics/somesy/tree/v0.8.0) <small>(2026-09-07)</small> { id="0.8.0" }
 
 - **Added**

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ organization. Existing project files are enabled as sync targets; absent files
 are disabled. Use `--output-file` to choose another path or `--overwrite` to
 replace an existing file.
 
+For scripts, `somesy init --non-interactive` never prompts. It writes the
+harvested metadata and warns about missing required values. To synchronize an
+incomplete file, explicitly use `somesy sync --pass-validation` or set
+`pass_validation = true` in the config.
+
 ```bash
 somesy init --output-file somesy.toml --overwrite
 ```

--- a/codemeta.json
+++ b/codemeta.json
@@ -271,5 +271,5 @@
   "runtimePlatform": "Python >=3.10",
   "issueTracker": "https://github.com/Materials-Data-Science-and-Informatics/somesy/issues",
   "dateCreated": "2023-05-12",
-  "dateModified": "2026-09-07"
+  "dateModified": "2026-09-08"
 }

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -284,6 +284,11 @@ email address. For an entity, it asks for the organization name and optionally
 an email address. Git authors count as project authors; therefore, the author
 prompt is shown only when no author was found in the harvested metadata.
 
+For scripts, use `somesy init --non-interactive`. It never prompts, warns about
+any missing required values, and writes the harvested metadata. To synchronize
+an incomplete file, explicitly use `somesy sync --pass-validation` or set
+`pass_validation = true` in the config; missing values are omitted from output.
+
 Detected project files are enabled as synchronization targets. Targets that are
 not present are disabled in the generated `[config]` section. The generated file
 is not overwritten by default:

--- a/src/somesy/cff/writer.py
+++ b/src/somesy/cff/writer.py
@@ -77,7 +77,7 @@ class CFF(ProjectMetadataWriter):
         if "abstract" in self._data:
             if "\n" in self._data["abstract"]:
                 self._data["abstract"] = LiteralScalarString(self._data["abstract"])
-        else:
+        elif self.description is not None:
             self._data["abstract"] = str(self.description)
 
         self._yaml.dump(self._data, path)

--- a/src/somesy/cli/init.py
+++ b/src/somesy/cli/init.py
@@ -22,12 +22,16 @@ app = typer.Typer()
 
 
 def _prompt_missing_metadata(
-    sources: list[tuple[Path, dict[str, Any]]], git_metadata
+    sources: list[tuple[Path, dict[str, Any]]],
+    git_metadata,
+    non_interactive: bool = False,
 ) -> dict[str, Any]:
-    """Prompt for required metadata that harvesting did not provide."""
+    """Prompt or warn for required metadata that harvesting did not provide."""
     harvested = [content for _, content in sources]
     if git_metadata is not None:
-        harvested.append(git_metadata.model_dump(exclude_none=True))
+        harvested.append(
+            git_metadata.model_dump(exclude_none=True, exclude_defaults=False)
+        )
     fallback: dict[str, Any] = {}
 
     for field, prompt in {
@@ -35,16 +39,22 @@ def _prompt_missing_metadata(
         "description": "Project description",
     }.items():
         if not any(source.get(field) for source in harvested):
-            fallback[field] = typer.prompt(prompt)
+            if non_interactive:
+                logger.warning("Missing required metadata: %s", field)
+            else:
+                fallback[field] = typer.prompt(prompt)
 
     if not any(source.get("license") for source in harvested):
-        while True:
-            value = typer.prompt("SPDX license")
-            try:
-                fallback["license"] = LicenseEnum(value)
-                break
-            except ValueError:
-                typer.echo(f"Unknown SPDX license: {value}")
+        if non_interactive:
+            logger.warning("Missing required metadata: license")
+        else:
+            while True:
+                value = typer.prompt("SPDX license")
+                try:
+                    fallback["license"] = LicenseEnum(value)
+                    break
+                except ValueError:
+                    typer.echo(f"Unknown SPDX license: {value}")
 
     def is_author(person: Any) -> bool:
         return (
@@ -59,26 +69,31 @@ def _prompt_missing_metadata(
         for key in ("people", "entities", "authors")
     )
     if not has_author:
-        author_type = typer.prompt("Author type", type=str, default="person").lower()
-        while author_type not in {"person", "entity"}:
-            typer.echo("Author type must be 'person' or 'entity'.")
-            author_type = typer.prompt("Author type", default="person").lower()
-        if author_type == "person":
-            person = {
-                "given_names": typer.prompt("Author given names"),
-                "family_names": typer.prompt("Author family names"),
-                "author": True,
-            }
-            email = typer.prompt("Author email", default="")
-            if email:
-                person["email"] = email
-            fallback["people"] = [Person(**person)]
+        if non_interactive:
+            logger.warning("Missing required metadata: author")
         else:
-            name = typer.prompt("Author organization")
-            fallback["entities"] = [{"name": name, "author": True}]
-            email = typer.prompt("Author email", default="")
-            if email:
-                fallback["entities"][0]["email"] = email
+            author_type = typer.prompt(
+                "Author type", type=str, default="person"
+            ).lower()
+            while author_type not in {"person", "entity"}:
+                typer.echo("Author type must be 'person' or 'entity'.")
+                author_type = typer.prompt("Author type", default="person").lower()
+            if author_type == "person":
+                person = {
+                    "given_names": typer.prompt("Author given names"),
+                    "family_names": typer.prompt("Author family names"),
+                    "author": True,
+                }
+                email = typer.prompt("Author email", default="")
+                if email:
+                    person["email"] = email
+                fallback["people"] = [Person(**person)]
+            else:
+                name = typer.prompt("Author organization")
+                fallback["entities"] = [{"name": name, "author": True}]
+                email = typer.prompt("Author email", default="")
+                if email:
+                    fallback["entities"][0]["email"] = email
 
     return fallback
 
@@ -95,6 +110,11 @@ def initialize(
         **file_arg_config,
     ),
     overwrite: bool = typer.Option(False, "--overwrite"),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Do not prompt for missing metadata; report warnings instead.",
+    ),
 ):
     """Harvest project metadata and create a somesy.toml file."""
     if ctx.invoked_subcommand is not None:
@@ -102,28 +122,36 @@ def initialize(
     root = Path.cwd()
     sources = harvest_sources(root)
     git_metadata = harvest_git(root)
-    fallback = _prompt_missing_metadata(sources, git_metadata)
+    fallback = _prompt_missing_metadata(sources, git_metadata, non_interactive)
     source_content = [content for _, content in sources]
     if fallback:
         source_content.append(fallback)
-    metadata = merge_metadata(source_content, git_metadata)
+    metadata = merge_metadata(
+        source_content, git_metadata, allow_incomplete=non_interactive
+    )
     source_names = {path.name for path, _ in sources}
-    config = None
-    if source_names:
-        config = SomesyConfig.model_validate(
-            {
-                f"no_sync_{key}": filename not in source_names
-                for key, filename in {
-                    "pyproject": "pyproject.toml",
-                    "package_json": "package.json",
-                    "julia": "Project.toml",
-                    "fortran": "fpm.toml",
-                    "pom_xml": "pom.xml",
-                    "mkdocs": "mkdocs.yml",
-                    "rust": "Cargo.toml",
-                }.items()
-            }
+    incomplete = (
+        any(
+            getattr(metadata, field, None) is None
+            for field in ("name", "description", "license")
         )
+        or not metadata.authors()
+    )
+    config = None
+    if source_names or incomplete:
+        config_data = {
+            f"no_sync_{key}": filename not in source_names
+            for key, filename in {
+                "pyproject": "pyproject.toml",
+                "package_json": "package.json",
+                "julia": "Project.toml",
+                "fortran": "fpm.toml",
+                "pom_xml": "pom.xml",
+                "mkdocs": "mkdocs.yml",
+                "rust": "Cargo.toml",
+            }.items()
+        }
+        config = SomesyConfig.model_validate(config_data)
     output = output_file if output_file.is_absolute() else root / output_file
     write_somesy_file(metadata, output, config=config, overwrite=overwrite)
     typer.echo(f"Created {output}")

--- a/src/somesy/cli/sync.py
+++ b/src/somesy/cli/sync.py
@@ -156,7 +156,7 @@ def sync(
         False,
         "--pass-validation",
         "-V",
-        help="Pass validation of metadata files (default: False)",
+        help="Allow incomplete input and pass output validation (default: False)",
     ),
     packages: list[Path] | None = typer.Option(
         None,

--- a/src/somesy/codemeta/writer.py
+++ b/src/somesy/codemeta/writer.py
@@ -305,18 +305,19 @@ class CodeMeta(ProjectMetadataWriter):
         else:
             self._upgrade_to_v3()
             self._data["@type"] = "SoftwareSourceCode"
-            self._data["author"] = []
+            if metadata.authors():
+                self._data["author"] = []
             self._data["maintainer"] = []
             self._data["contributor"] = []
 
         super().sync(metadata)
         if metadata.doi:
             self._data["identifier"] = f"https://doi.org/{metadata.doi}"
-        licenses = metadata.license
-        self.license = [
-            f"https://spdx.org/licenses/{license.value}"
-            for license in (licenses if isinstance(licenses, list) else [licenses])
-        ]
+        if licenses := metadata.license:
+            self.license = [
+                f"https://spdx.org/licenses/{license.value}"
+                for license in (licenses if isinstance(licenses, list) else [licenses])
+            ]
         self.contributors = metadata.contributors()
 
         if "softwareHelp" in self._data:

--- a/src/somesy/commands/sync.py
+++ b/src/somesy/commands/sync.py
@@ -134,7 +134,9 @@ def sync(somesy_input: SomesyInput, is_package: bool = False):
 
             for config_file in config_files:
                 try:
-                    package_input = SomesyInput.from_input_file(config_file)
+                    package_input = SomesyInput.from_input_file(
+                        config_file, allow_incomplete=bool(conf.pass_validation)
+                    )
                     logger.debug(f"Found config file: {config_file}")
                     break
                 except (FileNotFoundError, RuntimeError):

--- a/src/somesy/core/models.py
+++ b/src/somesy/core/models.py
@@ -245,7 +245,7 @@ class SomesyConfig(SomesyBaseModel):
     # property to pass validation for all inputs/outputs
     pass_validation: Annotated[
         bool | None,
-        Field(description="Pass validation for all output files."),
+        Field(description="Allow incomplete input and pass output validation."),
     ] = False
 
     # packages (sub-folders) for monorepos with their own somesy config
@@ -272,7 +272,8 @@ class SomesyConfig(SomesyBaseModel):
         """Based on the somesy config, load the complete somesy input."""
         # get metadata+config from specified input file
         somesy_input = SomesyInput.from_input_file(
-            self.input_file or Path("somesy.toml")
+            self.input_file or Path("somesy.toml"),
+            allow_incomplete=bool(self.pass_validation),
         )
         # update input with merged config settings (cli overrides config file)
         dct: dict[str, Any] = {}
@@ -794,13 +795,26 @@ class ProjectMetadata(SomesyBaseModel):
         return contributors
 
 
+class PartialProjectMetadata(ProjectMetadata):
+    """Validated project metadata that may omit normally required values."""
+
+    name: str | None = None  # type: ignore[assignment]
+    description: str | None = None  # type: ignore[assignment]
+    license: LicenseEnum | list[LicenseEnum] | None = None  # type: ignore[assignment]
+
+    @model_validator(mode="after")
+    def at_least_one_author(self) -> PartialProjectMetadata:
+        """Allow an author to be omitted while retaining all field validation."""
+        return self
+
+
 class SomesyInput(SomesyBaseModel):
     """The complete somesy input file (`somesy.toml`) or section (`pyproject.toml`)."""
 
     _origin: Path | None
 
     project: Annotated[
-        ProjectMetadata,
+        ProjectMetadata | PartialProjectMetadata,
         Field(description="Project metadata to be used and synchronized."),
     ]
     config: Annotated[
@@ -815,6 +829,10 @@ class SomesyInput(SomesyBaseModel):
     @model_validator(mode="after")
     def set_origin(self):
         """Set the origin of the input file."""
+        if isinstance(self.project, PartialProjectMetadata) and not bool(
+            self.config.pass_validation
+        ):
+            ProjectMetadata.model_validate(self.project.model_dump())
         if self.config and self.config.input_file:
             self._origin = self.config.input_file
         return self
@@ -835,9 +853,23 @@ class SomesyInput(SomesyBaseModel):
         return str(path).endswith("somesy.toml")
 
     @classmethod
-    def from_input_file(cls, path: Path) -> SomesyInput:
+    def from_input_file(
+        cls, path: Path, *, allow_incomplete: bool = False
+    ) -> SomesyInput:
         """Load somesy input from given file."""
         content = get_input_content(path)
-        ret = SomesyInput(**content)
+        config = SomesyConfig(**content.get("config", {}))
+        if allow_incomplete:
+            config.pass_validation = True
+        project_model = (
+            PartialProjectMetadata if config.pass_validation else ProjectMetadata
+        )
+        ret = cls.model_validate(
+            {
+                **content,
+                "project": project_model(**content["project"]),
+                "config": config,
+            }
+        )
         ret._origin = path
         return ret

--- a/src/somesy/core/writer.py
+++ b/src/somesy/core/writer.py
@@ -293,8 +293,10 @@ class ProjectMetadataWriter(ABC):
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync output file with other metadata files."""
-        self.name = metadata.name
-        self.description = metadata.description
+        if metadata.name is not None:
+            self.name = metadata.name
+        if metadata.description is not None:
+            self.description = metadata.description
 
         if metadata.version:
             self.version = metadata.version
@@ -302,15 +304,16 @@ class ProjectMetadataWriter(ABC):
         if metadata.keywords:
             self.keywords = metadata.keywords
 
-        self._sync_authors(metadata)
+        if metadata.authors():
+            self._sync_authors(metadata)
         self.maintainers = self._sync_person_list(
             self.maintainers, metadata.maintainers()
         )
 
-        licenses = metadata.license
-        self.license = (
-            licenses[0].value if isinstance(licenses, list) else licenses.value
-        )
+        if licenses := metadata.license:
+            self.license = (
+                licenses[0].value if isinstance(licenses, list) else licenses.value
+            )
 
         self.homepage = str(metadata.homepage) if metadata.homepage else None
         self.repository = str(metadata.repository) if metadata.repository else None

--- a/src/somesy/fortran/writer.py
+++ b/src/somesy/fortran/writer.py
@@ -139,8 +139,10 @@ class Fortran(ProjectMetadataWriter):
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync output file with other metadata files."""
-        self.name = metadata.name
-        self.description = metadata.description
+        if metadata.name is not None:
+            self.name = metadata.name
+        if metadata.description is not None:
+            self.description = metadata.description
 
         if metadata.version:
             self.version = metadata.version
@@ -148,7 +150,8 @@ class Fortran(ProjectMetadataWriter):
         if metadata.keywords:
             self.keywords = metadata.keywords
 
-        self.authors = metadata.authors()
+        if metadata.authors():
+            self.authors = metadata.authors()
         maintainers = metadata.maintainers()
 
         # set if not empty
@@ -156,11 +159,11 @@ class Fortran(ProjectMetadataWriter):
             # only one maintainer is allowed
             self.maintainers = maintainers
 
-        licenses = metadata.license
-        self.license = (
-            " OR ".join(license.value for license in licenses)
-            if isinstance(licenses, list)
-            else licenses.value
-        )
+        if licenses := metadata.license:
+            self.license = (
+                " OR ".join(license.value for license in licenses)
+                if isinstance(licenses, list)
+                else licenses.value
+            )
 
         self.homepage = str(metadata.homepage) if metadata.homepage else None

--- a/src/somesy/julia/writer.py
+++ b/src/somesy/julia/writer.py
@@ -104,7 +104,9 @@ class Julia(ProjectMetadataWriter):
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync output file with other metadata files."""
         # overridden to not sync fields that are not present in the Project.toml file
-        self.name = metadata.name
+        if metadata.name is not None:
+            self.name = metadata.name
         self.version = metadata.version
 
-        self._sync_authors(metadata)
+        if metadata.authors():
+            self._sync_authors(metadata)

--- a/src/somesy/merge.py
+++ b/src/somesy/merge.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Iterable
 from typing import Any
 
-from somesy.core.models import Entity, Person, ProjectMetadata
+from somesy.core.models import Entity, PartialProjectMetadata, Person, ProjectMetadata
 from somesy.git.models import GitAuthor, GitMetadata
 
 logger = logging.getLogger("somesy")
@@ -112,9 +112,12 @@ def _git_person(author: GitAuthor) -> Person | None:
 
 
 def merge_metadata(
-    sources: Iterable[dict[str, Any]], git: GitMetadata | None = None
+    sources: Iterable[dict[str, Any]],
+    git: GitMetadata | None = None,
+    *,
+    allow_incomplete: bool = False,
 ) -> ProjectMetadata:
-    """Merge harvested endpoint data and Git data into ProjectMetadata."""
+    """Merge harvested endpoint and Git data, optionally allowing missing fields."""
     data: dict[str, Any] = {"people": [], "entities": []}
     keywords: list[str] = []
 
@@ -149,4 +152,5 @@ def merge_metadata(
 
     if keywords:
         data["keywords"] = keywords
-    return ProjectMetadata(**data)
+    model = PartialProjectMetadata if allow_incomplete else ProjectMetadata
+    return model(**data)

--- a/src/somesy/mkdocs/writer.py
+++ b/src/somesy/mkdocs/writer.py
@@ -115,10 +115,13 @@ class MkDocs(ProjectMetadataWriter):
 
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync the MkDocs object with the ProjectMetadata object."""
-        self.name = metadata.name
-        self.description = metadata.description
+        if metadata.name is not None:
+            self.name = metadata.name
+        if metadata.description is not None:
+            self.description = metadata.description
         # no author merge since it is a free text field
-        self.authors = metadata.authors()
+        if metadata.authors():
+            self.authors = metadata.authors()
         if metadata.homepage:
             self.homepage = str(metadata.homepage)
         if metadata.repository:

--- a/src/somesy/pom_xml/writer.py
+++ b/src/somesy/pom_xml/writer.py
@@ -246,10 +246,10 @@ class POM(ProjectMetadataWriter):
         Use existing sync function from ProjectMetadataWriter but update repository and contributors.
         """
         super().sync(metadata)
-        licenses = metadata.license
-        self.license = (
-            [license.value for license in licenses]
-            if isinstance(licenses, list)
-            else licenses.value
-        )
+        if licenses := metadata.license:
+            self.license = (
+                [license.value for license in licenses]
+                if isinstance(licenses, list)
+                else licenses.value
+            )
         self.contributors = self._sync_person_list(self.contributors, metadata.people)

--- a/src/somesy/pyproject/writer.py
+++ b/src/somesy/pyproject/writer.py
@@ -269,7 +269,8 @@ class Poetry(PyprojectCommon):
         # Restore original _from_person method
         self._from_person = original_from_person  # type: ignore
 
-        self.license = license_expression(metadata.license)
+        if metadata.license:
+            self.license = license_expression(metadata.license)
 
         # For Poetry v2, convert authors and maintainers from array of tables to inline tables
         if self._poetry_version == 2:
@@ -341,7 +342,8 @@ class SetupTools(PyprojectCommon):
     def sync(self, metadata: ProjectMetadata) -> None:
         """Sync metadata with pyproject.toml file and fix license field."""
         super().sync(metadata)
-        self.license = license_expression(metadata.license)
+        if metadata.license:
+            self.license = license_expression(metadata.license)
 
 
 # ----

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -1,10 +1,15 @@
 """Tests for the metadata initialization command."""
 
+import json
 import subprocess
+import warnings
 
+import pytest
 from typer.testing import CliRunner
 
 from somesy.core.core import get_input_content
+from somesy.core.models import SomesyInput
+from somesy.git.models import GitAuthor, GitMetadata
 from somesy.main import app
 
 runner = CliRunner()
@@ -86,3 +91,125 @@ def test_init_prompts_for_entity_author_and_partial_metadata(tmp_path, monkeypat
     assert content["project"]["description"] == "A project"
     assert content["project"]["entities"][0]["name"] == "Example Org"
     assert content["project"]["entities"][0]["email"] == "org@example.com"
+
+
+def test_init_non_interactive_writes_partial_metadata(tmp_path, monkeypatch, caplog):
+    """Write harvested metadata without prompting and warn about missing fields."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "somesy.cli.init.harvest_sources",
+        lambda _: [(tmp_path / "pyproject.toml", {"name": "harvested"})],
+    )
+    monkeypatch.setattr("somesy.cli.init.harvest_git", lambda _: None)
+    monkeypatch.setattr(
+        "somesy.cli.init.typer.prompt",
+        lambda *_, **__: (_ for _ in ()).throw(AssertionError("unexpected prompt")),
+    )
+
+    result = runner.invoke(app, ["init", "--non-interactive"])
+
+    assert result.exit_code == 0, result.stdout
+    content = get_input_content(tmp_path / "somesy.toml")
+    assert content["project"] == {"name": "harvested"}
+    assert "pass_validation" not in content["config"]
+    assert [
+        record.message for record in caplog.records if record.levelname == "WARNING"
+    ] == [
+        "Missing required metadata: description",
+        "Missing required metadata: license",
+        "Missing required metadata: author",
+    ]
+
+
+def test_init_non_interactive_recognizes_git_author(tmp_path, monkeypatch, caplog):
+    """Do not warn when Git supplies the required author."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "somesy.cli.init.harvest_sources",
+        lambda _: [
+            (
+                tmp_path / "pyproject.toml",
+                {"name": "project", "description": "description", "license": "MIT"},
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "somesy.cli.init.harvest_git",
+        lambda _: GitMetadata(authors=[GitAuthor(name="Jane Doe")]),
+    )
+
+    result = runner.invoke(app, ["init", "--non-interactive"])
+
+    assert result.exit_code == 0, result.stdout
+    assert not [record for record in caplog.records if record.levelname == "WARNING"]
+    content = get_input_content(tmp_path / "somesy.toml")
+    assert content["project"]["people"][0]["author"] is True
+
+
+def test_non_interactive_partial_init_can_sync_codemeta(tmp_path, monkeypatch, caplog):
+    """Normalize harvested values and sync dependencies without a description."""
+    package_json = tmp_path / "package.json"
+    package_json.write_text(
+        json.dumps(
+            {
+                "name": "pipeline-project",
+                "version": "1.2.3",
+                "license": "MIT",
+                "dependencies": {"chalk": "^5.4.1", "lodash": "^4.17.21"},
+                "engines": {"node": ">=20"},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "somesy.cli.init.harvest_git",
+        lambda _: GitMetadata(authors=[GitAuthor(name="Jane Doe")]),
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message="Pydantic serializer warnings.*")
+        initialized = runner.invoke(app, ["init", "--non-interactive"])
+        strict_sync = runner.invoke(app, ["sync"])
+        synced = runner.invoke(app, ["sync", "--pass-validation"])
+
+    assert initialized.exit_code == 0, initialized.stdout
+    assert strict_sync.exit_code == 1
+    assert synced.exit_code == 0, synced.stdout
+    assert [record.message for record in caplog.records].count(
+        "Missing required metadata: description"
+    ) == 1
+    codemeta = json.loads((tmp_path / "codemeta.json").read_text())
+    assert "description" not in codemeta
+    assert "abstract" not in codemeta
+    assert {dependency["name"] for dependency in codemeta["softwareRequirements"]} == {
+        "chalk",
+        "lodash",
+    }
+
+
+def test_non_interactive_init_without_author_can_sync(tmp_path, monkeypatch):
+    """Load and sync partial metadata without reapplying the author invariant."""
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "pipeline-project", "license": "MIT"})
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("somesy.cli.init.harvest_git", lambda _: None)
+
+    initialized = runner.invoke(app, ["init", "--non-interactive"])
+    synced = runner.invoke(app, ["sync", "--pass-validation"])
+
+    assert initialized.exit_code == 0, initialized.stdout
+    assert synced.exit_code == 0, synced.stdout
+    codemeta = json.loads((tmp_path / "codemeta.json").read_text())
+    assert codemeta["author"] == []
+
+
+def test_partial_input_still_rejects_unknown_top_level_sections(tmp_path):
+    path = tmp_path / "somesy.toml"
+    path.write_text(
+        "[project]\nname = 'project'\n\n[config]\npass_validation = true\n"
+        "\n[unexpected]\nvalue = true\n"
+    )
+
+    with pytest.raises(ValueError):
+        SomesyInput.from_input_file(path)

--- a/tests/commands/test_sync.py
+++ b/tests/commands/test_sync.py
@@ -12,6 +12,7 @@ from somesy.codemeta import CodeMeta
 from somesy.commands.sync import _semantic_data, _sync_file, sync
 from somesy.core.models import (
     LicenseEnum,
+    PartialProjectMetadata,
     Person,
     ProjectMetadata,
     SomesyConfig,
@@ -217,6 +218,31 @@ def test_codemeta_derived_values_converge_after_one_write(tmp_path):
     assert data["softwareHelp"] == data["url"] == "https://example.com/project"
     _sync_codemeta(metadata, path, tmp_path)
     assert path.read_bytes() == first
+
+
+def test_codemeta_merge_preserves_authors_missing_from_partial_metadata(tmp_path):
+    path = tmp_path / "codemeta.json"
+    path.write_text(
+        json.dumps(
+            {
+                "@context": "https://w3id.org/codemeta/3.1",
+                "@type": "SoftwareSourceCode",
+                "author": [{"@type": "Organization", "name": "Existing Author"}],
+            }
+        )
+    )
+    _sync_file(
+        PartialProjectMetadata(name="project", license="MIT"),
+        path,
+        CodeMeta,
+        merge_codemeta=True,
+        pass_validation=True,
+        codemeta_sources={},
+    )
+
+    assert json.loads(path.read_text())["author"] == [
+        {"@type": "Organization", "name": "Existing Author"}
+    ]
 
 
 def test_sync_file_does_not_rewrite_unchanged_data(tmp_path):
@@ -524,6 +550,35 @@ def test_package_sync_missing_config(tmp_path, create_files, file_types):
     # Verify package files don't exist
     assert not (package_dir / "CITATION.cff").exists()
     assert not (package_dir / "codemeta.json").exists()
+
+
+def test_package_sync_pass_validation_loads_incomplete_input(tmp_path):
+    """Apply the root pass-validation setting while loading a package."""
+    package_dir = tmp_path / "package"
+    package_dir.mkdir()
+    (package_dir / "somesy.toml").write_text(
+        "[project]\nname = 'child'\nlicense = 'MIT'\n"
+    )
+    root = SomesyInput(
+        config=SomesyConfig(
+            input_file=tmp_path / "somesy.toml",
+            packages=[Path("package")],
+            no_sync_cff=True,
+            no_sync_pyproject=True,
+            no_sync_package_json=True,
+            no_sync_julia=True,
+            no_sync_fortran=True,
+            no_sync_pom_xml=True,
+            no_sync_mkdocs=True,
+            no_sync_rust=True,
+            pass_validation=True,
+        ),
+        project=_codemeta_metadata(),
+    )
+
+    sync(root)
+
+    assert (package_dir / "codemeta.json").exists()
 
 
 def test_sync_with_flags(create_files, file_types):

--- a/tests/merge/test_merge.py
+++ b/tests/merge/test_merge.py
@@ -3,8 +3,9 @@
 import subprocess
 
 import pytest
+from pydantic import ValidationError
 
-from somesy.core.models import Person
+from somesy.core.models import LicenseEnum, Person
 from somesy.git.harvest import harvest
 from somesy.git.models import GitAuthor, GitMetadata
 from somesy.harvest import harvest_sources
@@ -70,6 +71,39 @@ def test_merge_metadata_adds_git_authors_as_code_authors():
     assert [str(value) for value in (result.people[0].contribution_types or [])] == [
         "code"
     ]
+
+
+def test_allow_incomplete_still_rejects_invalid_metadata():
+    with pytest.raises(ValidationError):
+        merge_metadata(
+            [
+                {
+                    "name": "project",
+                    "description": "description",
+                    "license": "not-an-spdx-license",
+                    "people": [
+                        Person(given_names="Jane", family_names="Doe", author=True)
+                    ],
+                }
+            ],
+            allow_incomplete=True,
+        )
+
+
+def test_allow_incomplete_validates_supplied_metadata():
+    result = merge_metadata(
+        [
+            {
+                "name": "project",
+                "license": "MIT",
+                "people": [Person(given_names="Jane", family_names="Doe", author=True)],
+            }
+        ],
+        allow_incomplete=True,
+    )
+
+    assert result.description is None
+    assert result.license is LicenseEnum.MIT
 
 
 def _commit(path, name, email, message):


### PR DESCRIPTION
## Summary

- add `somesy init --non-interactive` for prompt-free metadata harvesting
- allow incomplete metadata to be synced explicitly with `--pass-validation`
- preserve validation of supplied values and omit missing values from outputs
- document the automated init and sync workflow

Closes #137